### PR TITLE
cmz demux notebook: fix GIF_PATH for docs build

### DIFF
--- a/examples/inverse_design/03_photonic_cmz_demux.ipynb
+++ b/examples/inverse_design/03_photonic_cmz_demux.ipynb
@@ -1043,7 +1043,11 @@
     "    return (*lines_anim, title_txt)\n",
     "\n",
     "ani = animation.FuncAnimation(fig, _frame, frames=len(ANIM_STEPS), interval=80, blit=True)\n",
-    "GIF_PATH = \"cmz_optimisation.gif\"\n",
+    "# Path is relative to the repo root — matches 02_oscillator and 04_hemt. MkDocs\n",
+    "# executes notebooks with CWD = repo root, so this lands the GIF next to the\n",
+    "# notebook source where the markdown reference below (and the docs hoist\n",
+    "# sentinel) can find it.\n",
+    "GIF_PATH = \"examples/inverse_design/cmz_optimisation.gif\"\n",
     "ani.save(GIF_PATH, writer=animation.PillowWriter(fps=12), dpi=130)\n",
     "plt.close(fig)\n",
     "print(f\"Saved → {GIF_PATH}  ({len(ANIM_STEPS)} frames)\")\n"


### PR DESCRIPTION
GIF_PATH was just "cmz_optimisation.gif", so running the notebook from the repo root (as MkDocs does) wrote the file to the repo root instead of next to the notebook. The markdown reference then resolved relative to the notebook directory and could not find it, which is why the animation did not render on the docs site.

Match the sibling notebooks (02_oscillator_hb_tuning, 04_hemt_pa_optimization): use the path relative to the repo root so the file lands next to the notebook source.