### PR TITLE
s_to_y: switch to Kurokawa power-wave form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docs/images/lcr_animation.gif
 docs/examples/*.gif
 examples/**/*.gif
 circulax/_version.py
+debug_scripts/
+cmz_optimisation.gif

--- a/circulax/s_transforms.py
+++ b/circulax/s_transforms.py
@@ -45,24 +45,20 @@ def _sanitize_port(name: str) -> str:
 
 
 @jax.jit
-def s_to_y(S: jax.Array, z0: float = 1.0) -> jax.Array:
+def s_to_y(S: jax.Array, z0: complex = 1.0 + 1e-12j) -> jax.Array:
     """Convert an S-parameter matrix to an admittance (Y) matrix.
 
-    Uses the formula ``Y = (1/z0) * (I - S) * (I + S)^-1``. Requires dense
-    matrix inversion; if a component can be defined directly in terms of a
-    Y-matrix it should be, to avoid the overhead of this conversion.
-
-    Args:
-        S: S-parameter matrix of shape ``(..., n, n)``.
-        z0: Reference impedance in ohms. Defaults to ``1.0``.
-
-    Returns:
-        Y-matrix of the same shape and dtype as ``S``.
-
+    Kurokawa power-wave form: ``Y = (I - S) (z0 S + z0* I)^-1``. Reduces to
+    ``(1/z0) (I - S) (I + S)^-1`` for real ``z0``. A small ``Im(z0)`` keeps
+    the inverse well-conditioned when ``S`` has eigenvalues at -1 (e.g. an
+    ideal lossless symmetric splitter).
     """
     n = S.shape[-1]
-    eye = jnp.eye(n, dtype=S.dtype)
-    return (1.0 / z0) * (eye - S) @ jnp.linalg.inv(eye + S)
+    eye = jnp.eye(n, dtype=jnp.complex128)
+    Sc = S.astype(jnp.complex128)
+    z0c = jnp.asarray(z0, dtype=jnp.complex128)
+    M = z0c * Sc + jnp.conj(z0c) * eye
+    return jnp.linalg.solve(M.swapaxes(-1, -2), (eye - Sc).swapaxes(-1, -2)).swapaxes(-1, -2)
 
 
 def sax_component(fn: callable, *, name: str | None = None) -> callable:


### PR DESCRIPTION
Avoids the (I+S) singularity at lossless symmetric splitters (e.g. an ideal 1x2 at exactly 50/50). Default z0 = 1+1e-12j; reduces to the textbook formula for real z0. Same op count, uses solve over inv.