### PR TITLE
fix: schemdraw in dev env, long tests on PRs, CamelCase docs note

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,12 +51,10 @@ jobs:
         run: pixi run -e ${{ matrix.env }} pytest_run
 
   test_long:
-    # Slow tests (notebook execution) only run on push to main, not on PRs,
-    # so PR feedback stays fast while main keeps a full-coverage check.
-    # Only on Linux — papermill notebook execution is not tested on Windows/macOS.
+    # Slow tests (notebook execution) run on PRs to main and on push to main.
+    # Only on Linux / py313 — papermill notebook execution is not tested on Windows/macOS.
     name: "test_long / ubuntu-latest / py313"
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/writing_components.md
+++ b/docs/writing_components.md
@@ -25,6 +25,9 @@ def MyComponent(signals, s, [t], **params):
     # 2. Return (Flows, Storage)
 ```
 
+!!! note "CamelCase function names"
+    Component functions use **CamelCase** (`Resistor`, `VoltageSourceAC`) because the decorator promotes them into `equinox.Module` **classes** — Python convention for classes. In the netlist `"component"` key you reference them by whatever string key you pass to `compile_netlist`'s `models` dict, which is typically the lowercase name (e.g. `"resistor"`). The two names are independent.
+
 
 ### Arguments
 


### PR DESCRIPTION
## Summary

- Adds `schemdraw` to the `dev` pixi feature (conda-forge) so `nbrun`, long tests, and docs deployment have it available — it is not a package dependency
- Removes the `push`-only guard on `test_long` so notebook execution is validated on PRs to main, not just after merge
- Adds a callout note in `writing_components.md` explaining why component functions use CamelCase (the decorator promotes them to `equinox.Module` classes)

## Test plan

- [ ] `pixi run python -c "import schemdraw"` passes in the default environment
- [ ] Opening a PR to main triggers both the fast matrix (`test`) and `test_long` jobs
- [ ] Docs callout renders correctly under `pixi run docs-serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)