### PR TITLE
fix(netlist): remove global monkeypatch of sax.Netlist

### DIFF
--- a/circulax/netlist.py
+++ b/circulax/netlist.py
@@ -44,10 +44,6 @@ circulaxNetlist = Annotated[
 
 Netlist = circulaxNetlist
 
-# Monkeypatch sax.Netlist to be circulaxNetlist so that all functions using sax.Netlist
-# May need to make this explicit in the future
-sax_netlist.Netlist = circulaxNetlist  # type: ignore[assignment]
-
 
 # ---------------------------------------------------------------------------
 # kfnetlist-native node mapping


### PR DESCRIPTION
Fixes gdsfactory/circulax#32: importing circulax monkeypatched `sax.saxtypes.netlist.Netlist` at import time, a global process-wide side effect. Because `circulaxNetlist` omits the `nets` field, this silently dropped `nets` from SAX's own recursive netlist coercion for any unrelated SAX simulation running in the same process after `import circulax`.

## Changes

- Removed the 4-line monkeypatch block from `circulax/netlist.py` that assigned `sax_netlist.Netlist = circulaxNetlist`
- Kept the `circulaxNetlist`/`Netlist` type alias itself since it's still used as a legacy SAX-format type annotation

## Context

- Verified kfnetlist is now the primary netlist backend: `compile_netlist` converts SAX-format dicts to `kfnetlist.Netlist` via a hand-written `sax_to_kfnetlist` union-find converter, not via sax's validation/coercion machinery
- Nothing in circulax's runtime code depends on the patched `sax.Netlist` global — the `circulaxNetlist`/`Netlist` alias is only used as a static type hint in tests
- Git history shows the monkeypatch predates the kfnetlist migration (added in an early "rename_project" commit, before kfnetlist became primary), confirming it's dead legacy code

## Test Plan

- [ ] Reproduced the original bug from the issue (nets dropped after `import circulax` on main)
- [ ] Confirmed fix resolves the bug (nets preserved after removal)
- [ ] Full test suite passes unchanged (`pixi run pytest_run`): 216 passed, 16 skipped in both before and after runs, no regressions