### PR TITLE
feat: add port_aliases parameter to component decorators

### DIFF
--- a/circulax/components/base_component.py
+++ b/circulax/components/base_component.py
@@ -254,6 +254,7 @@ def _build_component(  # noqa: C901
     amplitude_param: str = "",
     setup_fn: Any = None,
     differentiable_params: "tuple[str, ...] | None" = None,
+    port_aliases: "dict[str, str | tuple[str, ...]] | None" = None,
 ) -> type[CircuitComponent]:
     """Compile a physics function into a :class:`CircuitComponent` subclass.
 
@@ -276,6 +277,12 @@ def _build_component(  # noqa: C901
             physics function accepts a time argument ``t``.
         amplitude_param: Name of the parameter representing the source
             amplitude for DC homotopy stepping.  Empty string for passives.
+        port_aliases: Optional mapping from a canonical port name (must be a
+            member of ``ports``) to one or more alternate port names that may
+            appear in a netlist instead (e.g. ``{"p1": "P", "p2": "N"}``).
+            Consumed by ``compiler.py``'s ``_resolve_port_index`` so callers
+            can wire up a netlist using either name without duplicating the
+            physics.
 
     Returns:
         A new :class:`CircuitComponent` subclass named after ``fn``.
@@ -285,6 +292,8 @@ def _build_component(  # noqa: C901
             reserved arguments, if any parameter lacks a default value, if a
             non-source component declares a ``t`` parameter, or if the dry-run
             raises an exception.
+        ValueError: If ``port_aliases`` references a canonical name that is
+            not in ``ports``.
 
     """
     reserved = ("signals", "s", "t") if uses_time else ("signals", "s")
@@ -538,6 +547,16 @@ def _build_component(  # noqa: C901
 
     cls = type(fn.__name__, (CircuitComponent,), namespace)
     cls.__doc__ = fn.__doc__
+
+    if port_aliases:
+        normalized_aliases: dict[str, tuple[str, ...]] = {}
+        for canonical, raw in port_aliases.items():
+            if canonical not in ports:
+                msg = f"{fn.__name__}: port_aliases key {canonical!r} is not in ports {ports}"
+                raise ValueError(msg)
+            normalized_aliases[canonical] = (raw,) if isinstance(raw, str) else tuple(raw)
+        cls._sanitized_to_raw_ports = normalized_aliases
+
     return cls
 
 
@@ -545,6 +564,7 @@ def component(
     ports: tuple[str, ...] = (),
     states: tuple[str, ...] = (),
     amplitude_param: str = "",
+    port_aliases: "dict[str, str | tuple[str, ...]] | None" = None,
 ) -> Any:
     """Decorator for defining a time-independent circuit component.
 
@@ -563,6 +583,11 @@ def component(
             amplitude (e.g. ``"I"`` for a current source). When non-empty,
             DC homotopy solvers will scale this parameter during stepping.
             Leave empty (default) for passive components.
+        port_aliases: Optional mapping from a canonical port name to one or
+            more alternate names a netlist may use instead, e.g.
+            ``{"p1": "P", "p2": "N"}``. Lets integrators (e.g. Mosaic/kfnetlist)
+            reuse this component's physics under their own port-naming
+            convention without redefining it.
 
     Returns:
         A decorator that accepts a physics function and returns a
@@ -576,13 +601,16 @@ def component(
             return {"p1": i, "p2": -i}, {}
 
     """
-    return lambda fn: _build_component(fn, ports, states, uses_time=False, amplitude_param=amplitude_param)
+    return lambda fn: _build_component(
+        fn, ports, states, uses_time=False, amplitude_param=amplitude_param, port_aliases=port_aliases
+    )
 
 
 def source(
     ports: tuple[str, ...] = (),
     states: tuple[str, ...] = (),
     amplitude_param: str = "",
+    port_aliases: "dict[str, str | tuple[str, ...]] | None" = None,
 ) -> Any:
     """Decorator for defining a time-dependent circuit component.
 
@@ -599,6 +627,9 @@ def source(
             DC homotopy solvers will scale this parameter during stepping.
             Leave empty (default) for time-dependent components that are not
             primary excitation sources.
+        port_aliases: Optional mapping from a canonical port name to one or
+            more alternate names a netlist may use instead. See
+            :func:`component`.
 
     Returns:
         A decorator that accepts a physics function and returns a
@@ -612,4 +643,6 @@ def source(
             return {"p1": s.i_src, "p2": -s.i_src, "i_src": constraint}, {}
 
     """
-    return lambda fn: _build_component(fn, ports, states, uses_time=True, amplitude_param=amplitude_param)
+    return lambda fn: _build_component(
+        fn, ports, states, uses_time=True, amplitude_param=amplitude_param, port_aliases=port_aliases
+    )

--- a/circulax/components/electronic.py
+++ b/circulax/components/electronic.py
@@ -11,15 +11,17 @@ from circulax.components.base_component import (
     source,
 )
 
+_PN_ALIASES = {"p1": "P", "p2": "N"}
 
-@component(ports=("p1", "p2"))
+
+@component(ports=("p1", "p2"), port_aliases=_PN_ALIASES)
 def Resistor(signals: Signals, s: States, R: float = 1e3) -> PhysicsReturn:
     """Ohm's Law: I = V/R."""
     i = (signals.p1 - signals.p2) / (R + 1e-12)
     return {"p1": i, "p2": -i}, {}
 
 
-@component(ports=("p1", "p2"))
+@component(ports=("p1", "p2"), port_aliases=_PN_ALIASES)
 def Capacitor(signals: Signals, s: States, C: float = 1e-12) -> PhysicsReturn:
     """Q = C * V.
     Returns Charge (q) so the solver computes I = dq/dt.
@@ -29,7 +31,7 @@ def Capacitor(signals: Signals, s: States, C: float = 1e-12) -> PhysicsReturn:
     return {}, {"p1": q_val, "p2": -q_val}
 
 
-@component(ports=("p1", "p2"), states=("i_L",))
+@component(ports=("p1", "p2"), states=("i_L",), port_aliases=_PN_ALIASES)
 def Inductor(signals: Signals, s: States, L: float = 1e-9) -> PhysicsReturn:
     """V = L * di/dt formulated via flux: f['i_L'] = V, q['i_L'] = -L*i_L."""
     v_drop = signals.p1 - signals.p2

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,7 +1,8 @@
 import jax
 import jax.numpy as jnp
+import pytest
 
-from circulax.components.base_component import CircuitComponent, PhysicsReturn, Signals, States
+from circulax.components.base_component import CircuitComponent, PhysicsReturn, Signals, States, component
 
 # Import components to be tested
 from circulax.components.electronic import (
@@ -244,3 +245,27 @@ def test_subclass_init_creates_namedtuples() -> None:
 
     s = MyComp._VarsType_S(10)  # noqa: SLF001
     assert s.s1 == 10
+
+
+# --- port_aliases (gdsfactory/circulax#30) ---
+
+
+def test_component_port_aliases_sets_raw_port_map() -> None:
+    assert Resistor._sanitized_to_raw_ports == {"p1": ("P",), "p2": ("N",)}  # noqa: SLF001
+
+
+def test_component_port_aliases_accepts_tuple_of_aliases() -> None:
+    @component(ports=("p1", "p2"), port_aliases={"p1": ("P", "A")})
+    def Foo(signals: Signals, s: States, R: float = 1.0) -> PhysicsReturn:
+        i = (signals.p1 - signals.p2) / R
+        return {"p1": i, "p2": -i}, {}
+
+    assert Foo._sanitized_to_raw_ports == {"p1": ("P", "A")}  # noqa: SLF001
+
+
+def test_component_port_aliases_rejects_unknown_canonical_name() -> None:
+    with pytest.raises(ValueError, match="port_aliases"):
+
+        @component(ports=("p1", "p2"), port_aliases={"p3": "P"})
+        def Bad(signals: Signals, s: States, R: float = 1.0) -> PhysicsReturn:
+            return {"p1": 0.0, "p2": 0.0}, {}

--- a/tests/test_kfnetlist.py
+++ b/tests/test_kfnetlist.py
@@ -153,6 +153,53 @@ def test_compile_netlist_accepts_kfnetlist(simple_lrc_kfnetlist):
         assert g.var_indices.shape[0] > 0
 
 
+def test_compile_netlist_resolves_mosaic_pn_port_aliases():
+    """Mosaic emits built-in R/L/C parts wired via 'P'/'N' port names, while
+    circulax's canonical Resistor/Capacitor declare 'p1'/'p2'. compile_netlist
+    should resolve these via the component's port_aliases without requiring a
+    netlist rewrite or a duplicate component definition (gdsfactory/circulax#30).
+    """
+    from circulax.components.electronic import Capacitor, Resistor
+
+    models_map = {"resistor": Resistor, "capacitor": Capacitor, "ground": lambda: 0}
+
+    nl = kfnl.Netlist()
+    nl.create_inst(name="GND", kcl="", component="ground")
+    nl.create_inst(name="R1", kcl="", component="resistor", settings={"R": 100.0})
+    nl.create_inst(name="C1", kcl="", component="capacitor", settings={"C": 1e-9})
+
+    gnd = kfnl.PortRef(instance="GND", port="p1")
+    nl.create_net(gnd, kfnl.PortRef(instance="R1", port="N"))
+    nl.create_net(kfnl.PortRef(instance="R1", port="P"), kfnl.PortRef(instance="C1", port="P"))
+    nl.create_net(kfnl.PortRef(instance="C1", port="N"), gnd)
+
+    groups, _sys_size, pmap = compile_netlist(nl, models_map)
+
+    assert "resistor" in groups
+    assert "capacitor" in groups
+
+    # Canonical p1/p2 keys are back-filled even though the netlist wired via P/N.
+    assert pmap["R1,p2"] == 0
+    assert pmap["C1,p2"] == 0
+    assert pmap["R1,p1"] == pmap["C1,p1"]
+    assert pmap["R1,p1"] > 0
+
+
+def test_compile_netlist_missing_port_reports_alias_in_error():
+    from circulax.components.electronic import Resistor
+
+    models_map = {"resistor": Resistor, "ground": lambda: 0}
+
+    nl = kfnl.Netlist()
+    nl.create_inst(name="GND", kcl="", component="ground")
+    nl.create_inst(name="R1", kcl="", component="resistor", settings={"R": 100.0})
+    nl.create_net(kfnl.PortRef(instance="GND", port="p1"), kfnl.PortRef(instance="R1", port="N"))
+    # R1's other terminal (p1/P) is left unconnected.
+
+    with pytest.raises(ValueError, match="aliases: R1,P"):
+        compile_netlist(nl, models_map)
+
+
 def test_compile_netlist_kfnetlist_dc_solve():
     """Full DC solve with kfnetlist-constructed netlist (no delay on source)."""
     from circulax.components.electronic import Capacitor, Inductor, Resistor, VoltageSource


### PR DESCRIPTION
Fixes #30

Adds a `port_aliases` parameter to the `component()` and `source()` decorators to map internal port names to external port names. Resolves conflicts when netlist sources (e.g., Mosaic/kfnetlist) use different naming conventions ("P"/"N") than circulax's canonical components ("p1"/"p2").

- Reuses existing `_sanitized_to_raw_ports` compiler mechanism
- Applies port aliases to Resistor, Capacitor, and Inductor
- Includes tests at decorator and compile_netlist levels