### PR TITLE
Fix port impedance and complex voltage reconstruction in 2N AC sweep solver

### DIFF
--- a/circulax/solvers/ac_sweep.py
+++ b/circulax/solvers/ac_sweep.py
@@ -286,10 +286,11 @@ def _setup_ac_sweep_2n(
                 Y = Y.at[rows_fd + N, cols_fd].add(Y_flat.imag)
 
             Y = Y.at[port_nodes_arr, port_nodes_arr].add(1.0 / z0_arr)
+            Y = Y.at[port_nodes_arr + N, port_nodes_arr + N].add(1.0 / z0_arr)
             Y = Y.at[ground_2n, ground_2n].add(GROUND_STIFFNESS)
 
             V = jnp.linalg.solve(Y, RHS)
-            V_ports = V[port_nodes_arr, :]
+            V_ports = V[port_nodes_arr, :] + 1j * V[port_nodes_arr + N, :]
             return V_ports - jnp.eye(N_ports, dtype=jnp.complex128)
 
         return jax.vmap(_solve_one_freq)(freqs)

--- a/tests/test_ac_sweep.py
+++ b/tests/test_ac_sweep.py
@@ -520,8 +520,8 @@ def test_non_holomorphic_matches_holomorphic_for_waveguide(waveguide_complex_set
     S_2n = run_ac_2n(y_dc_2, freqs)
 
     assert S_2n.shape == S_wirtinger.shape
-    assert jnp.allclose(jnp.abs(S_2n), jnp.abs(S_wirtinger), atol=1e-6), (
-        f"Max |S| error: {jnp.max(jnp.abs(jnp.abs(S_2n) - jnp.abs(S_wirtinger))):.2e}"
+    assert jnp.allclose(S_2n, S_wirtinger, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S_2n - S_wirtinger)):.2e}"
     )
 
 
@@ -547,7 +547,44 @@ def test_non_holomorphic_via_circuit():
     assert jnp.isfinite(jnp.abs(S)).all()
 
     S_std = circuit.sp(ports="in", freqs=freqs, z0=_OPT_Z0)
-    assert jnp.allclose(jnp.abs(S), jnp.abs(S_std), atol=1e-6)
+    assert jnp.allclose(S, S_std, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S - S_std)):.2e}"
+    )
+
+
+def test_non_holomorphic_lossy_waveguide():
+    """2N path matches Wirtinger for a lossy waveguide where |S11| < 1."""
+    from circulax.components.photonic import OpticalWaveguide
+
+    models_map = {"waveguide": OpticalWaveguide, "ground": lambda: 0}
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "WG1": {
+                "component": "waveguide",
+                "settings": {"length_um": 500.0, "loss_dB_cm": 3.0, "neff": 2.4, "n_group": 4.0,
+                              "center_wavelength_nm": 1310.0, "wavelength_nm": 1310.0},
+            },
+        },
+        "connections": {"WG1,p2": "GND,p1"},
+        "ports": {"in": "WG1,p1"},
+    }
+    groups, num_vars, pmap = compile_netlist(net_dict, models_map)
+    solver = analyze_circuit(groups, num_vars, is_complex=True)
+    sys_size = num_vars * 2
+    y_dc = solver.solve_dc(groups, jnp.zeros(sys_size))
+    freqs = jnp.logspace(6, 10, 20)
+
+    run_ac_w = setup_ac_sweep(groups, num_vars, [pmap["WG1,p1"]], z0=_OPT_Z0, is_complex=True)
+    S_wirtinger = run_ac_w(y_dc, freqs)
+
+    run_ac_2n = setup_ac_sweep(groups, num_vars, [pmap["WG1,p1"]], z0=_OPT_Z0, holomorphic=False)
+    S_2n = run_ac_2n(y_dc, freqs)
+
+    assert jnp.any(jnp.abs(S_2n[:, 0, 0]) < 0.99), "Lossy waveguide should have |S11| < 1"
+    assert jnp.allclose(S_2n, S_wirtinger, atol=1e-6), (
+        f"Max complex error: {jnp.max(jnp.abs(S_2n - S_wirtinger)):.2e}"
+    )
 
 
 def test_non_holomorphic_jit(waveguide_netlist):


### PR DESCRIPTION
## Summary
- Fixed port termination impedance missing from imaginary block in `_setup_ac_sweep_2n` (only real diagonal was set)
- Fixed complex port voltage reconstruction dropping imaginary component during backsubstitution
- Both bugs affected all `holomorphic=False` AC sweeps

## Details
- Port impedance now correctly set for both real block `[port, port]` and imaginary block `[port+N, port+N]`
- Complex voltage reconstruction now uses full state vector: `V[port_nodes, :]` + `1j * V[port_nodes + N, :]`
- Tightened tests from magnitude-only (`jnp.abs`) to full complex comparison
- Added new lossy waveguide test case where |S11| < 1 validates physical correctness

Fixes #43