### PR TITLE
Add time-delay transient solver and vector-fitting components

### DIFF
--- a/circulax/__init__.py
+++ b/circulax/__init__.py
@@ -3,7 +3,7 @@
 from circulax._version import __version__
 from circulax.circuit import Circuit, compile_circuit
 from circulax.compiler import compile_netlist
-from circulax.components.rational import rational_component, rational_fdomain_component
+from circulax.components.rational import rational_component, rational_delay_component, rational_fdomain_component
 from circulax.netlist import (
     build_net_map,
     build_net_map_kfnetlist,

--- a/circulax/__init__.py
+++ b/circulax/__init__.py
@@ -3,6 +3,7 @@
 from circulax._version import __version__
 from circulax.circuit import Circuit, compile_circuit
 from circulax.compiler import compile_netlist
+from circulax.components.rational import rational_component, rational_fdomain_component
 from circulax.netlist import (
     build_net_map,
     build_net_map_kfnetlist,

--- a/circulax/compiler.py
+++ b/circulax/compiler.py
@@ -72,6 +72,13 @@ class ComponentGroup(eqx.Module):
     combined_func: Any = eqx.field(static=True, default=None)
     holomorphic: bool = eqx.field(static=True, default=False)
 
+    # Fixed time-delay support (see circulax.solvers.assembly). ``has_delay``
+    # gates the delay-history lookup so undelayed groups pay no cost;
+    # ``tau_func(params) -> tau`` computes a single instance's delay, vmapped
+    # over the group's batched params by the assembly layer.
+    has_delay: bool = eqx.field(static=True, default=False)
+    tau_func: Any = eqx.field(static=True, default=None)
+
 
 def get_model_width(func: callable) -> int:
     """Determines the size of the 'vars' vector expected by the model."""
@@ -366,6 +373,8 @@ def compile_netlist(  # noqa: C901, PLR0912, PLR0915
             amplitude_param=getattr(comp_cls, "amplitude_param", ""),
             combined_func=_combined_func,
             holomorphic=getattr(comp_cls, "_holomorphic", True),
+            has_delay=getattr(comp_cls, "_has_delay", False),
+            tau_func=getattr(comp_cls, "tau_of", None) if getattr(comp_cls, "_has_delay", False) else None,
         )
 
     # --- Process OSDI buckets (requires circulax[verilog-a] / bosdi) ---

--- a/circulax/components/__init__.py
+++ b/circulax/components/__init__.py
@@ -1,0 +1,9 @@
+from circulax.components.photonic import OpticalDelayLine, delay_line_fdomain
+from circulax.components.rational import rational_component, rational_fdomain_component
+
+__all__ = [
+    "OpticalDelayLine",
+    "delay_line_fdomain",
+    "rational_component",
+    "rational_fdomain_component",
+]

--- a/circulax/components/__init__.py
+++ b/circulax/components/__init__.py
@@ -1,9 +1,10 @@
 from circulax.components.photonic import OpticalDelayLine, delay_line_fdomain
-from circulax.components.rational import rational_component, rational_fdomain_component
+from circulax.components.rational import rational_component, rational_delay_component, rational_fdomain_component
 
 __all__ = [
     "OpticalDelayLine",
     "delay_line_fdomain",
     "rational_component",
+    "rational_delay_component",
     "rational_fdomain_component",
 ]

--- a/circulax/components/base_component.py
+++ b/circulax/components/base_component.py
@@ -140,6 +140,8 @@ class CircuitComponent(eqx.Module):
             resistive (``f``) and reactive (``q``) contributions respectively.
 
         """
+        hist = kwargs.pop("hist", None)
+
         if y is None and not kwargs:
             is_scalar = isinstance(t, (int, float)) or (hasattr(t, "shape") and t.shape == ())
             if not is_scalar:
@@ -158,7 +160,7 @@ class CircuitComponent(eqx.Module):
             signals = self._VarsType_P(*_get_args(self.ports)) if self._VarsType_P else ()
             s = self._VarsType_S(*_get_args(self.states)) if self._VarsType_S else ()
 
-        return self._invoke_physics(signals, s, t, self)
+        return self._invoke_physics(signals, s, t, self, hist)
 
     @classmethod
     def solver_call(
@@ -166,6 +168,7 @@ class CircuitComponent(eqx.Module):
         t: float,
         y: jax.Array,
         args: Any,
+        hist: jax.Array | None = None,
     ) -> tuple[jax.Array, jax.Array]:
         """Evaluate the component physics (solver entry point).
 
@@ -182,6 +185,11 @@ class CircuitComponent(eqx.Module):
                 ``{"R": 100.0}`` or an object (e.g. the component instance
                 itself) whose attributes match the parameter names. Must not
                 be a raw scalar.
+            hist: Delayed port-voltage vector of shape ``(n_ports,)``, i.e.
+                this instance's own ports evaluated at ``t - tau`` rather than
+                ``t``. Only consumed by components declaring a ``hist``
+                argument (see :func:`component`/:func:`source`); ``None``
+                otherwise.
 
         Returns:
             A two-tuple ``(f_vec, q_vec)`` of JAX arrays, each of shape
@@ -189,7 +197,7 @@ class CircuitComponent(eqx.Module):
             contributions for every port and state variable.
 
         """
-        return cls._fast_physics(y, args, t)
+        return cls._fast_physics(y, args, t, hist)
 
     # -----------------------------------------------------------------------
     # Internal Dispatchers (wired up by decorator)
@@ -204,6 +212,7 @@ class CircuitComponent(eqx.Module):
         s: Any,
         t: float,
         params: Any,
+        hist: Any = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Trampoline used by ``__call__`` to dispatch to the user physics function.
 
@@ -216,6 +225,8 @@ class CircuitComponent(eqx.Module):
             s: Namedtuple of state variable values.
             t: Current simulation time.
             params: Parameter container (instance or dict).
+            hist: Delayed port-voltage namedtuple/tuple, or ``None``. Only
+                consumed by components declaring a ``hist`` argument.
 
         Returns:
             A two-tuple ``(f, q)`` of physics dicts.
@@ -351,6 +362,21 @@ def _build_component(  # noqa: C901
     if has_init_arg:
         param_specs = param_specs[1:]
 
+    # Optional delay-history slot. When the physics function declares ``hist``
+    # as the next non-reserved positional argument (after ``init``, if
+    # present), the framework injects the component's own port voltages
+    # evaluated at ``t - tau`` instead of ``t``, where ``tau`` is computed by
+    # a ``@<Component>.delay``-registered function. Requires ``ports`` to be
+    # non-empty. See ``circulax.solvers.assembly`` for how the delayed read
+    # is computed (a fixed-size accepted-step history buffer + ``jnp.interp``,
+    # vmapped per-instance since ``tau`` may vary across instances).
+    has_hist_arg = bool(param_specs) and param_specs[0].name == "hist"
+    if has_hist_arg:
+        param_specs = param_specs[1:]
+        if not ports:
+            msg = f"{fn.__name__}: 'hist' argument requires non-empty ports."
+            raise TypeError(msg)
+
     if not uses_time:
         for p in param_specs:
             if p.name == "t":
@@ -366,19 +392,19 @@ def _build_component(  # noqa: C901
     _dummy_S = namedtuple("States", states)(*([0.0] * len(states))) if states else ()  # noqa: PYI024
     _defaults = {p.name: p.default for p in param_specs}
 
+    # Dry-run only validates non-injected args; ``init``/``hist`` will be
+    # injected by the closure once registered via ``.setup``/``.delay`` —
+    # pass structural placeholders (empty dict / zero ports) here instead.
+    _dry_positional = [_dummy_P, _dummy_S]
+    if uses_time:
+        _dry_positional.append(0.0)
+    if has_init_arg:
+        _dry_positional.append({})
+    if has_hist_arg:
+        _dry_positional.append(_dummy_P)
+
     try:
-        if has_init_arg:
-            # Dry-run only validates non-init args; ``init`` will be injected
-            # by the closure once the user registers ``.setup`` — pass an
-            # empty dict here as a structural placeholder.
-            if uses_time:
-                fn(_dummy_P, _dummy_S, 0.0, {}, **_defaults)
-            else:
-                fn(_dummy_P, _dummy_S, {}, **_defaults)
-        elif uses_time:
-            fn(_dummy_P, _dummy_S, 0.0, **_defaults)
-        else:
-            fn(_dummy_P, _dummy_S, **_defaults)
+        fn(*_dry_positional, **_defaults)
     except Exception as exc:
         # Bodies that index into init with concrete keys will fail the
         # placeholder dry-run; that's expected and harmless. Suppress only
@@ -432,28 +458,67 @@ def _build_component(  # noqa: C901
         sub_kw = {k: v for k, v in kw.items() if k in accepts}
         return setup_fn(**sub_kw)
 
+    # Mutable cell for the delay function — populated by the
+    # ``@<Component>.delay`` classmethod after class construction, mirroring
+    # ``_setup_cell`` above.
+    _tau_cell: list[Any] = [None]
+
+    def _resolve_tau(kw: dict[str, Any]) -> Any:
+        """Run the registered delay fn with the current params, returning tau."""
+        tau_fn = _tau_cell[0]
+        if tau_fn is None:
+            msg = (
+                f"{fn.__name__}: physics function declares a 'hist' argument "
+                f"but no delay function has been registered. "
+                f"Use ``@{fn.__name__}.delay`` to register one."
+            )
+            raise RuntimeError(msg)
+        tau_sig = inspect.signature(tau_fn)
+        has_var_kw = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD
+            for p in tau_sig.parameters.values()
+        )
+        if has_var_kw:
+            return tau_fn(**kw)
+        accepts = {p.name for p in tau_sig.parameters.values()}
+        sub_kw = {k: v for k, v in kw.items() if k in accepts}
+        return tau_fn(**sub_kw)
+
+    def _build_positional(signals: Any, s: Any, t: float, init_value: Any, hist_signals: Any) -> list[Any]:
+        positional = [signals, s]
+        if uses_time:
+            positional.append(t)
+        if has_init_arg:
+            positional.append(init_value)
+        if has_hist_arg:
+            positional.append(hist_signals)
+        return positional
+
     if len(full_keys) == 0:
-        _fast_physics = lambda v, p, t: (jnp.zeros(0), jnp.zeros(0))  # noqa: E731
+        _fast_physics = lambda v, p, t, hist=None: (jnp.zeros(0), jnp.zeros(0))  # noqa: E731
     else:
 
         def _fast_physics(
             vars_vec: jax.Array,
             params: Any,
             t: float,
+            hist: jax.Array | None = None,
         ) -> tuple[jax.Array, jax.Array]:
             signals = _PortsType(*vars_vec[:n_p]) if _PortsType else ()
             s = _StatesType(*vars_vec[n_p:]) if _StatesType else ()
             kw = {name: _extract_param(params, name) for name in _param_names}
-            if has_init_arg:
-                init_value = _resolve_init(kw)
-                if uses_time:
-                    f_dict, q_dict = _user_fn(signals, s, t, init_value, **kw)
-                else:
-                    f_dict, q_dict = _user_fn(signals, s, init_value, **kw)
-            elif uses_time:
-                f_dict, q_dict = _user_fn(signals, s, t, **kw)
-            else:
-                f_dict, q_dict = _user_fn(signals, s, **kw)
+            init_value = _resolve_init(kw) if has_init_arg else None
+            # hist is None outside the delay-aware solver path (e.g. the DC
+            # operating-point solve in circulax.solvers.linear, which has no
+            # history buffer yet) -- default to zero so those callers don't
+            # need to know about delayed components at all.
+            hist_signals = (
+                _PortsType(*(hist[:n_p] if hist is not None else jnp.zeros_like(vars_vec[:n_p])))
+                if has_hist_arg
+                else None
+            )
+            positional = _build_positional(signals, s, t, init_value, hist_signals)
+            f_dict, q_dict = _user_fn(*positional, **kw)
             f_vals = [f_dict.get(k, 0.0) for k in full_keys]
             q_vals = [q_dict.get(k, 0.0) for k in full_keys]
             return jnp.array(f_vals), jnp.array(q_vals)
@@ -466,12 +531,13 @@ def _build_component(  # noqa: C901
             s: Any,
             t: float,
             params: Any,
+            hist: Any = None,
         ) -> tuple[dict, dict]:
             kw = {name: _extract_param(params, name) for name in _param_names}
-            if has_init_arg:
-                init_value = _resolve_init(kw)
-                return _user_fn(signals, s, t, init_value, **kw)
-            return _user_fn(signals, s, t, **kw)
+            init_value = _resolve_init(kw) if has_init_arg else None
+            hist_signals = _PortsType(*(hist if hist is not None else [0.0] * n_p)) if has_hist_arg else None
+            positional = _build_positional(signals, s, t, init_value, hist_signals)
+            return _user_fn(*positional, **kw)
     else:
 
         def _invoke_physics(
@@ -480,12 +546,13 @@ def _build_component(  # noqa: C901
             s: Any,
             t: float,
             params: Any,
+            hist: Any = None,
         ) -> tuple[dict, dict]:
             kw = {name: _extract_param(params, name) for name in _param_names}
-            if has_init_arg:
-                init_value = _resolve_init(kw)
-                return _user_fn(signals, s, init_value, **kw)
-            return _user_fn(signals, s, **kw)
+            init_value = _resolve_init(kw) if has_init_arg else None
+            hist_signals = _PortsType(*(hist if hist is not None else [0.0] * n_p)) if has_hist_arg else None
+            positional = _build_positional(signals, s, t, init_value, hist_signals)
+            return _user_fn(*positional, **kw)
 
     annotations = {p.name: (p.annotation if p.annotation is not inspect.Parameter.empty else Any) for p in param_specs}
 
@@ -557,6 +624,49 @@ def _build_component(  # noqa: C901
         cls_inner._setup_fn_ref = staticmethod(setup_fn)
         return cls_inner
 
+    def _register_delay(cls_inner: type, tau_fn: Any) -> type:
+        """Register a fixed-delay function on the component class.
+
+        Used as ``@<Component>.delay`` decorator. The registered function is
+        called with the component's own params (filtered to those it
+        declares) and must return the delay ``tau`` — the physics function
+        then receives ``hist`` as this instance's own port voltages at
+        ``t - tau``. Requires the physics function to declare ``hist`` as a
+        reserved argument (see :func:`_build_component`).
+
+        Returns ``cls_inner`` for decorator chaining.
+
+        Raises:
+            TypeError: physics function did not declare a ``hist`` arg.
+            RuntimeError: ``.delay`` was already registered on this class.
+
+        """
+        if not has_hist_arg:
+            msg = (
+                f"@{fn.__name__}.delay requires the physics function to declare "
+                f"a 'hist' argument (after 'init', if present). Add ``hist`` to "
+                f"the signature, e.g. ``def {fn.__name__}(signals, s, hist, "
+                f"length_um=100.0): ...``"
+            )
+            raise TypeError(msg)
+        if _tau_cell[0] is not None:
+            msg = (
+                f"@{fn.__name__}.delay is already registered. Re-register "
+                f"is intentionally rejected to catch typos."
+            )
+            raise RuntimeError(msg)
+        if not callable(tau_fn):
+            msg = f"@{fn.__name__}.delay expects a callable; got {type(tau_fn).__name__}"
+            raise TypeError(msg)
+        _tau_cell[0] = tau_fn
+        cls_inner._tau_fn_ref = staticmethod(tau_fn)
+        return cls_inner
+
+    def _tau_of(params: Any) -> Any:
+        """Compute tau for a single instance's params — vmapped by assembly.py over a group."""
+        kw = {name: _extract_param(params, name) for name in _param_names}
+        return _resolve_tau(kw)
+
     namespace = {
         "__annotations__": annotations,
         "ports": ports,
@@ -569,6 +679,11 @@ def _build_component(  # noqa: C901
         "_has_init_arg": has_init_arg,
         "_setup_fn_ref": None,
         "setup": classmethod(_register_setup),
+        "_has_hist_arg": has_hist_arg,
+        "_has_delay": has_hist_arg,
+        "_tau_fn_ref": None,
+        "delay": classmethod(_register_delay),
+        "tau_of": staticmethod(_tau_of),
         # Expose static/diff param name splits for _install_custom_jvp.
         "_static_param_names": tuple(sorted(_static_names)),
         "_diff_param_names": _diff_param_names_tuple,

--- a/circulax/components/photonic.py
+++ b/circulax/components/photonic.py
@@ -69,6 +69,68 @@ def OpticalWaveguide(
     return {"p1": i_vec[0], "p2": i_vec[1]}, {}
 
 
+@component(ports=("p1", "p2"), states=("i_p2",))
+def OpticalDelayLine(
+    signals: Signals,
+    s: States,
+    hist: Signals,
+    length_um: float = 100.0,
+    loss_dB_cm: float = 1.0,
+    neff: float = 2.4,
+    n_group: float = 4.0,
+    wavelength_nm: float = 1310.0,
+) -> PhysicsReturn:
+    """Waveguide modelled as an explicit time-of-flight delay line (real group delay).
+
+    Unlike :func:`OpticalWaveguide` -- which is a steady-state S-matrix stamp
+    only valid for CW/frequency-domain analysis -- this component enforces
+    the actual transient envelope delay: the output field at ``p2`` is the
+    input field at ``p1`` from ``tau = length_um * n_group / c`` seconds ago,
+    attenuated and phase-shifted, via a VCVS-style constraint (same pattern as
+    :func:`TunableBeamSplitter`). ``p1`` carries no self-stamp and must be
+    driven by a connected source/component, matching that same convention.
+
+    See ``circulax.solvers.assembly`` for how ``hist`` (the delayed local
+    state) is computed -- a fixed-size accepted-step history buffer read via
+    ``jnp.interp``, vmapped per-instance since ``tau`` may vary across
+    instances of different length. Adaptive step-size controllers (e.g.
+    ``PIDController``) are supported (see gdsfactory/circulax#2): the
+    proposed step is automatically clamped to the smallest active ``tau``
+    across the circuit. ``ConstantStepSize`` remains unclamped -- an
+    explicit ``dt0`` larger than ``tau`` still raises.
+
+    Args:
+        signals: Field amplitudes at input (``p1``) and output (``p2``).
+        s: Branch current state variable ``i_p2``, carrying the VCVS current
+            injected at the output port.
+        hist: This instance's own port fields at ``t - tau``, injected by the
+            solver. Only ``hist.p1`` is used.
+        length_um: Waveguide length in micrometres. Defaults to ``100.0``.
+        loss_dB_cm: Propagation loss in dB/cm. Defaults to ``1.0``.
+        neff: Effective refractive index, used for the carrier phase shift
+            over the delay. Defaults to ``2.4``.
+        n_group: Group refractive index; sets the propagation delay via
+            ``tau = length_um * n_group / c``. Defaults to ``4.0``.
+        wavelength_nm: Operating wavelength in nm. Defaults to ``1310.0``.
+
+    """
+    phi = 2.0 * jnp.pi * neff * (length_um / wavelength_nm) * 1000.0
+    loss_val = loss_dB_cm * (length_um / 10000.0)
+    T_mag = 10.0 ** (-loss_val / 20.0)
+    T = T_mag * jnp.exp(-1j * phi)
+
+    constraint = signals.p2 - T * hist.p1
+
+    return {"p1": 0.0, "p2": s.i_p2, "i_p2": constraint}, {}
+
+
+@OpticalDelayLine.delay
+def _optical_delay_line_tau(length_um: float = 100.0, n_group: float = 4.0) -> float:
+    """Group delay ``tau = length / v_group`` in seconds (``length_um`` in micrometres)."""
+    c_um_per_s = 2.99792458e14  # speed of light, um/s
+    return (length_um * n_group) / c_um_per_s
+
+
 @component(ports=("grating", "waveguide"), holomorphic=True)
 def Grating(
     signals: Signals,

--- a/circulax/components/photonic.py
+++ b/circulax/components/photonic.py
@@ -7,7 +7,7 @@ import jax.nn as jnn
 import jax.numpy as jnp
 
 from circulax.components.base_component import PhysicsReturn, Signals, States, component, source
-from circulax.s_transforms import s_to_y
+from circulax.s_transforms import fdomain_component, s_to_y
 
 # ===========================================================================
 # Passive Optical Components (S-Matrix based)
@@ -129,6 +129,45 @@ def _optical_delay_line_tau(length_um: float = 100.0, n_group: float = 4.0) -> f
     """Group delay ``tau = length / v_group`` in seconds (``length_um`` in micrometres)."""
     c_um_per_s = 2.99792458e14  # speed of light, um/s
     return (length_um * n_group) / c_um_per_s
+
+
+@fdomain_component(ports=("p1", "p2"))
+def delay_line_fdomain(
+    f: float,
+    length_um: float = 100.0,
+    loss_dB_cm: float = 1.0,
+    n_group: float = 4.0,
+) -> jnp.ndarray:
+    """Frequency-domain delay line for AC and harmonic-balance analysis.
+
+    Models a pure transmission-line group delay: ``S21 = T_mag * exp(-j 2pi f tau)``
+    where ``tau = length_um * n_group / c`` and ``T_mag`` accounts for
+    propagation loss.  The S-matrix is converted to a Y-matrix via
+    :func:`s_to_y`.
+
+    This is a frequency-domain-only component (``f`` = modulation / signal
+    frequency, e.g. 1 GHz for an AC sweep).  Carrier-phase effects
+    (``neff``, ``wavelength_nm``) belong in the wavelength-domain
+    :func:`OpticalWaveguide` and are intentionally excluded here.
+
+    This component is AC/HB-only; it cannot be used in transient simulation
+    (fdomain components raise at transient setup time).
+
+    Args:
+        f: Modulation frequency in Hz (supplied by the AC/HB solver).
+        length_um: Waveguide length in micrometres. Defaults to ``100.0``.
+        loss_dB_cm: Propagation loss in dB/cm. Defaults to ``1.0``.
+        n_group: Group refractive index; sets the propagation delay via
+            ``tau = length_um * n_group / c``. Defaults to ``4.0``.
+
+    """
+    c_um_per_s = 2.99792458e14
+    loss_val = loss_dB_cm * (length_um / 10000.0)
+    T_mag = 10.0 ** (-loss_val / 20.0)
+    tau = (length_um * n_group) / c_um_per_s
+    T = T_mag * jnp.exp(-1j * 2.0 * jnp.pi * f * tau)
+    S = jnp.array([[0.0, T], [T, 0.0]], dtype=jnp.complex128)
+    return s_to_y(S)
 
 
 @component(ports=("grating", "waveguide"), holomorphic=True)

--- a/circulax/components/rational.py
+++ b/circulax/components/rational.py
@@ -1,0 +1,217 @@
+"""Factory functions for creating circulax components from vfitax SSModel."""
+from __future__ import annotations
+
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from circulax.components.base_component import CircuitComponent, _extract_param
+
+
+def rational_component(
+    ss: Any,
+    name: str = "RationalModel",
+    z0: complex = 50.0,
+    holomorphic: bool = True,
+) -> type[CircuitComponent]:
+    """Create a time-domain component from a vfitax SSModel.
+
+    Maps the state-space transfer function H(s) = C diag(1/(s-A)) B + D + s E
+    onto circulax's DAE formulation F(y) + dQ/dt = 0:
+
+        Port i:  f[port_i] = (C @ x + D @ v)_i    q[port_i] = (E @ v)_i
+        State j: f[x_j]    = -(A_j x_j + (B @ v)_j)   q[x_j]    = x_j
+
+    The resulting component works in AC sweep, harmonic balance, and transient
+    with zero solver changes. The SS arrays are stored as JAX-traceable Equinox
+    fields, enabling differentiation through the model.
+
+    Args:
+        ss: SSModel from vfitax (A, B, C, D, E arrays).
+        name: Class name for the generated component.
+        z0: Reference impedance (stored for documentation; not used in stamp).
+        holomorphic: Whether to use the fast N×N Wirtinger AC path.
+
+    Returns:
+        A CircuitComponent subclass with Nc ports and Nc*N states.
+
+    Note:
+        Currently requires ``is_complex=True`` in ``analyze_circuit`` and
+        ``setup_ac_sweep``, even for electrical (real-valued) circuits. A future
+        real-pair block form (``_ss_to_real_pairs``) would halve the system size
+        for circuits with conjugate pole pairs.
+    """
+    A = np.asarray(ss.A, dtype=np.complex128)
+    B = np.asarray(ss.B, dtype=np.complex128)
+    C = np.asarray(ss.C, dtype=np.complex128)
+    D = np.asarray(ss.D, dtype=np.complex128)
+    E = np.asarray(ss.E, dtype=np.complex128)
+
+    Nc = D.shape[0]
+    n_states = A.shape[0]
+    N = n_states // Nc
+
+    min_pole_mag = float(np.min(np.abs(A[:N].real)))
+    if min_pole_mag < 1e-14:
+        raise ValueError(
+            f"SSModel has a pole at or near the origin (min |Re(pole)| = {min_pole_mag:.2e}). "
+            f"This would create a singular DC stamp."
+        )
+
+    ports = tuple(f"p{i+1}" for i in range(Nc))
+    states = tuple(f"x{j}" for j in range(n_states))
+    n_p = Nc
+
+    _param_names = ("ss_A", "ss_B", "ss_C", "ss_D", "ss_E")
+
+    def _fast_physics(
+        vars_vec: jax.Array,
+        params: Any,
+        t: float,
+        hist: jax.Array | None = None,
+    ) -> tuple[jax.Array, jax.Array]:
+        ss_A = _extract_param(params, "ss_A")
+        ss_B = _extract_param(params, "ss_B")
+        ss_C = _extract_param(params, "ss_C")
+        ss_D = _extract_param(params, "ss_D")
+        ss_E = _extract_param(params, "ss_E")
+
+        v = vars_vec[:n_p].astype(jnp.complex128)
+        x = vars_vec[n_p:].astype(jnp.complex128)
+
+        i_port = ss_C @ x + ss_D @ v
+        f_state = -(ss_A * x + (ss_B @ v))
+        f_vals = jnp.concatenate([i_port, f_state])
+
+        q_port = ss_E @ v
+        q_state = x
+        q_vals = jnp.concatenate([q_port, q_state])
+
+        return f_vals, q_vals
+
+    def _invoke_physics(
+        self: CircuitComponent,
+        signals: Any,
+        s: Any,
+        t: float,
+        params: Any,
+        hist: Any = None,
+    ) -> tuple[dict, dict]:
+        ss_A = _extract_param(params, "ss_A")
+        ss_B = _extract_param(params, "ss_B")
+        ss_C = _extract_param(params, "ss_C")
+        ss_D = _extract_param(params, "ss_D")
+        ss_E = _extract_param(params, "ss_E")
+
+        v = jnp.array([getattr(signals, p) for p in ports], dtype=jnp.complex128)
+        x = jnp.array([getattr(s, st) for st in states], dtype=jnp.complex128)
+
+        i_port = ss_C @ x + ss_D @ v
+        f_state = -(ss_A * x + (ss_B @ v))
+
+        f_dict = {p: i_port[i] for i, p in enumerate(ports)}
+        f_dict.update({st: f_state[j] for j, st in enumerate(states)})
+
+        q_port = ss_E @ v
+        q_dict = {p: q_port[i] for i, p in enumerate(ports)}
+        q_dict.update({st: x[j] for j, st in enumerate(states)})
+
+        return f_dict, q_dict
+
+    namespace: dict[str, Any] = {
+        "__annotations__": {
+            "ss_A": jnp.ndarray,
+            "ss_B": jnp.ndarray,
+            "ss_C": jnp.ndarray,
+            "ss_D": jnp.ndarray,
+            "ss_E": jnp.ndarray,
+        },
+        "ports": ports,
+        "states": states,
+        "_fast_physics": staticmethod(_fast_physics),
+        "_invoke_physics": _invoke_physics,
+        "_uses_time": False,
+        "_holomorphic": holomorphic,
+        "amplitude_param": "",
+        "_has_init_arg": False,
+        "_has_hist_arg": False,
+        "_has_delay": False,
+        "_static_param_names": (),
+        "_diff_param_names": _param_names,
+        "ss_A": eqx.field(default_factory=lambda: jnp.array(A)),
+        "ss_B": eqx.field(default_factory=lambda: jnp.array(B)),
+        "ss_C": eqx.field(default_factory=lambda: jnp.array(C)),
+        "ss_D": eqx.field(default_factory=lambda: jnp.array(D)),
+        "ss_E": eqx.field(default_factory=lambda: jnp.array(E)),
+    }
+
+    cls = type(name, (CircuitComponent,), namespace)
+    return cls
+
+
+def rational_fdomain_component(
+    ss: Any,
+    name: str = "RationalFdomainModel",
+) -> type[CircuitComponent]:
+    """Create a frequency-domain oracle component from a vfitax SSModel.
+
+    Evaluates H(j2*pi*f) directly. Works in AC sweep and harmonic balance
+    but not transient. Used as a test reference for rational_component.
+
+    Args:
+        ss: SSModel from vfitax.
+        name: Class name for the generated component.
+
+    Returns:
+        A CircuitComponent subclass with _is_fdomain = True.
+
+    """
+    A_val = jnp.array(np.asarray(ss.A, dtype=np.complex128))
+    B_val = jnp.array(np.asarray(ss.B, dtype=np.complex128))
+    C_val = jnp.array(np.asarray(ss.C, dtype=np.complex128))
+    D_val = jnp.array(np.asarray(ss.D, dtype=np.complex128))
+    E_val = jnp.array(np.asarray(ss.E, dtype=np.complex128))
+
+    Nc = D_val.shape[0]
+    ports = tuple(f"p{i+1}" for i in range(Nc))
+
+    def _fast_physics(f: float, args: Any) -> jnp.ndarray:
+        ss_A = _extract_param(args, "ss_A")
+        ss_B = _extract_param(args, "ss_B")
+        ss_C = _extract_param(args, "ss_C")
+        ss_D = _extract_param(args, "ss_D")
+        ss_E = _extract_param(args, "ss_E")
+        s = 1j * 2.0 * jnp.pi * f
+        resolvent = 1.0 / (s - ss_A)
+        return ss_C @ (resolvent[:, None] * ss_B) + ss_D + s * ss_E
+
+    @classmethod
+    def solver_call(cls, f: float, args: Any) -> jnp.ndarray:
+        return cls._fast_physics(f, args)
+
+    namespace: dict[str, Any] = {
+        "__annotations__": {
+            "ss_A": jnp.ndarray,
+            "ss_B": jnp.ndarray,
+            "ss_C": jnp.ndarray,
+            "ss_D": jnp.ndarray,
+            "ss_E": jnp.ndarray,
+        },
+        "ports": ports,
+        "states": (),
+        "_is_fdomain": True,
+        "_uses_time": False,
+        "_fast_physics": staticmethod(_fast_physics),
+        "solver_call": solver_call,
+        "ss_A": eqx.field(default_factory=lambda: A_val),
+        "ss_B": eqx.field(default_factory=lambda: B_val),
+        "ss_C": eqx.field(default_factory=lambda: C_val),
+        "ss_D": eqx.field(default_factory=lambda: D_val),
+        "ss_E": eqx.field(default_factory=lambda: E_val),
+    }
+
+    cls = type(name, (CircuitComponent,), namespace)
+    return cls

--- a/circulax/components/rational.py
+++ b/circulax/components/rational.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from circulax.components.base_component import CircuitComponent, _extract_param
+from circulax.s_transforms import s_to_y
 
 
 def rational_component(
@@ -211,6 +212,98 @@ def rational_fdomain_component(
         "ss_C": eqx.field(default_factory=lambda: C_val),
         "ss_D": eqx.field(default_factory=lambda: D_val),
         "ss_E": eqx.field(default_factory=lambda: E_val),
+    }
+
+    cls = type(name, (CircuitComponent,), namespace)
+    return cls
+
+
+def rational_delay_component(
+    ss: Any,
+    tau: Any,
+    name: str = "RationalDelayModel",
+    z0: float = 50.0,
+) -> type[CircuitComponent]:
+    """Create an fdomain component from SSModel + per-port delay.
+
+    Evaluates the full cascade ``delay(tau/2) * rational * delay(tau/2)`` in
+    the frequency domain via reference-plane re-embedding::
+
+        S_full(f) = P(f) @ S_deembed(f) @ P(f)
+
+    where ``P = diag(exp(-j*2*pi*f*tau_k/2))``, ``S_deembed`` comes from the
+    rational model's Y(s), and the result is converted back to Y for the
+    circuit solver.
+
+    AC sweep and harmonic balance only — not usable in transient (fdomain
+    component). For transient, use :func:`rational_component` alone and wire
+    delay elements separately.
+
+    Args:
+        ss: SSModel from vfitax (A, B, C, D, E arrays).
+        tau: Per-port group delay in seconds, shape ``(Nc,)``.
+        name: Class name for the generated component.
+        z0: Reference impedance for S/Y conversion.
+
+    Returns:
+        A CircuitComponent subclass with ``_is_fdomain = True``.
+    """
+    A_val = jnp.array(np.asarray(ss.A, dtype=np.complex128))
+    B_val = jnp.array(np.asarray(ss.B, dtype=np.complex128))
+    C_val = jnp.array(np.asarray(ss.C, dtype=np.complex128))
+    D_val = jnp.array(np.asarray(ss.D, dtype=np.complex128))
+    E_val = jnp.array(np.asarray(ss.E, dtype=np.complex128))
+    tau_val = jnp.array(np.asarray(tau, dtype=np.float64))
+
+    Nc = D_val.shape[0]
+    ports = tuple(f"p{i+1}" for i in range(Nc))
+    z0_val = float(z0)
+
+    def _fast_physics(f: float, args: Any) -> jnp.ndarray:
+        ss_A = _extract_param(args, "ss_A")
+        ss_B = _extract_param(args, "ss_B")
+        ss_C = _extract_param(args, "ss_C")
+        ss_D = _extract_param(args, "ss_D")
+        ss_E = _extract_param(args, "ss_E")
+        tau_arr = _extract_param(args, "tau")
+
+        s = 1j * 2.0 * jnp.pi * f
+        resolvent = 1.0 / (s - ss_A)
+        Y_deemb = ss_C @ (resolvent[:, None] * ss_B) + ss_D + s * ss_E
+
+        eye = jnp.eye(Nc, dtype=jnp.complex128)
+        S_deemb = (eye - z0_val * Y_deemb) @ jnp.linalg.inv(eye + z0_val * Y_deemb)
+
+        phase = jnp.exp(-1j * jnp.pi * f * tau_arr)
+        P = jnp.diag(phase)
+        S_full = P @ S_deemb @ P
+        return s_to_y(S_full, z0=z0_val)
+
+    @classmethod
+    def solver_call(cls, f: float, args: Any) -> jnp.ndarray:
+        return cls._fast_physics(f, args)
+
+    namespace: dict[str, Any] = {
+        "__annotations__": {
+            "ss_A": jnp.ndarray,
+            "ss_B": jnp.ndarray,
+            "ss_C": jnp.ndarray,
+            "ss_D": jnp.ndarray,
+            "ss_E": jnp.ndarray,
+            "tau": jnp.ndarray,
+        },
+        "ports": ports,
+        "states": (),
+        "_is_fdomain": True,
+        "_uses_time": False,
+        "_fast_physics": staticmethod(_fast_physics),
+        "solver_call": solver_call,
+        "ss_A": eqx.field(default_factory=lambda: A_val),
+        "ss_B": eqx.field(default_factory=lambda: B_val),
+        "ss_C": eqx.field(default_factory=lambda: C_val),
+        "ss_D": eqx.field(default_factory=lambda: D_val),
+        "ss_E": eqx.field(default_factory=lambda: E_val),
+        "tau": eqx.field(default_factory=lambda: tau_val),
     }
 
     cls = type(name, (CircuitComponent,), namespace)

--- a/circulax/solvers/ac_sweep.py
+++ b/circulax/solvers/ac_sweep.py
@@ -46,7 +46,11 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
-from circulax.solvers.assembly import assemble_gc_complex, assemble_gc_complex_2n, assemble_gc_real
+from circulax.solvers.assembly import (
+    assemble_gc_complex,
+    assemble_gc_complex_2n,
+    assemble_gc_real,
+)
 from circulax.solvers.linear import GROUND_STIFFNESS, _build_index_arrays
 
 
@@ -286,10 +290,11 @@ def _setup_ac_sweep_2n(
                 Y = Y.at[rows_fd + N, cols_fd].add(Y_flat.imag)
 
             Y = Y.at[port_nodes_arr, port_nodes_arr].add(1.0 / z0_arr)
+            Y = Y.at[port_nodes_arr + N, port_nodes_arr + N].add(1.0 / z0_arr)
             Y = Y.at[ground_2n, ground_2n].add(GROUND_STIFFNESS)
 
             V = jnp.linalg.solve(Y, RHS)
-            V_ports = V[port_nodes_arr, :]
+            V_ports = V[port_nodes_arr, :] + 1j * V[port_nodes_arr + N, :]
             return V_ports - jnp.eye(N_ports, dtype=jnp.complex128)
 
         return jax.vmap(_solve_one_freq)(freqs)

--- a/circulax/solvers/assembly.py
+++ b/circulax/solvers/assembly.py
@@ -23,6 +23,7 @@ algebra kernels.
 import functools
 
 import equinox as eqx
+import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -210,13 +211,82 @@ def _is_osdi(group) -> bool:
     return OsdiComponentGroup is not None and isinstance(group, OsdiComponentGroup)
 
 
+# ---------------------------------------------------------------------------
+# Fixed time-delay support
+# ---------------------------------------------------------------------------
+#
+# Delayed reads interpolate a per-instance query time against the accepted-
+# step history buffer (``hist_t``/``hist_y``, written by circuit_diffeq.py's
+# ``_circuit_loop``). Delay ``tau`` may vary per instance within a group (e.g.
+# waveguides of different lengths), so the interpolation itself must be
+# vmapped over the instance axis -- computing one shared delayed vector and
+# then slicing it (as ``y_guess[group.var_indices]`` does for the undelayed
+# read) would only be correct if every instance shared the same tau.
+
+
+def _interp_delayed(hist_t: Array, hist_cols: Array, tau: Array, idx: Array, t1: float) -> Array:
+    """Per-instance delayed read via ``jnp.interp``, vmapped over ``idx``'s leading axis.
+
+    Args:
+        hist_t: Ascending accepted-step sample times, shape ``(max_steps+1,)``
+            (inf-padded tail past the current step count).
+        hist_cols: Sample values to interpolate, shape ``(max_steps+1, M)``.
+        tau: Per-instance delay, shape ``(N,)``.
+        idx: Per-instance column indices into ``hist_cols``, shape ``(N, width)``.
+        t1: Current evaluation time.
+
+    Returns:
+        Delayed values, shape ``(N, width)`` -- the same layout as
+        ``y_guess[idx]`` for the undelayed read.
+
+    """
+
+    def _read_one(tau_i: Array, idx_i: Array) -> Array:
+        tq = t1 - tau_i
+        cols = hist_cols[:, idx_i]  # (max_steps+1, width)
+        return jax.vmap(lambda c: jnp.interp(tq, hist_t, c), in_axes=1)(cols)
+
+    return jax.vmap(_read_one)(tau, idx)
+
+
+def _group_tau(group, params, dt: float) -> Array:
+    """Per-instance tau, guarded against delays shorter than the current step."""
+    tau = jax.vmap(group.tau_func)(params)
+    msg = f"circulax delay: group '{group.name}' has tau < dt; delayed components require tau >= dt."
+    return eqxi.error_if(tau, tau < dt, msg)
+
+
+def _real_hist_locs(group, params, t1: float, dt: float, hist_t: Array, hist_y: Array) -> Array:
+    """Per-instance delayed local-var vector, real system layout."""
+    tau = _group_tau(group, params, dt)
+    return _interp_delayed(hist_t, hist_y, tau, group.var_indices, t1)
+
+
+def _complex_hist_locs(group, params, t1: float, dt: float, hist_t: Array, hist_y: Array, half_size: int) -> Array:
+    """Per-instance delayed local-var vector, complex (unrolled real/imag) layout."""
+    tau = _group_tau(group, params, dt)
+    hist_r = _interp_delayed(hist_t, hist_y[:, :half_size], tau, group.var_indices, t1)
+    hist_i = _interp_delayed(hist_t, hist_y[:, half_size:], tau, group.var_indices, t1)
+    return hist_r + 1j * hist_i
+
+
 def _real_physics(v: Array, p: Array, group, t1: float) -> tuple[Array, Array]:
     return group.physics_func(y=v, args=p, t=t1)
+
+
+def _real_physics_hist(v: Array, p: Array, h: Array, group, t1: float) -> tuple[Array, Array]:
+    return group.physics_func(y=v, args=p, t=t1, hist=h)
 
 
 def _complex_physics(vr: Array, vi: Array, p: Array, group, t1: float) -> tuple[Array, Array, Array, Array]:
     v = vr + 1j * vi
     f, q = group.physics_func(y=v, args=p, t=t1)
+    return f.real, f.imag, q.real, q.imag
+
+
+def _complex_physics_hist(vr: Array, vi: Array, p: Array, h: Array, group, t1: float) -> tuple[Array, Array, Array, Array]:
+    v = vr + 1j * vi
+    f, q = group.physics_func(y=v, args=p, t=t1, hist=h)
     return f.real, f.imag, q.real, q.imag
 
 
@@ -229,6 +299,14 @@ def _primal_and_jac_real(f, v: Array, p: Array) -> tuple[tuple[Array, Array], tu
     """
     n = v.shape[0]
     g = lambda v_: f(v_, p)  # close over p; differentiate w.r.t. v only
+    (f_vals, q_vals), (dfs, dqs) = jax.vmap(lambda e: jax.jvp(g, (v,), (e,)))(jnp.eye(n))
+    return (f_vals[0], q_vals[0]), (dfs.T, dqs.T)
+
+
+def _primal_and_jac_real_hist(f, v: Array, p: Array, h: Array) -> tuple[tuple[Array, Array], tuple[Array, Array]]:
+    """Same as :func:`_primal_and_jac_real`, with a fixed (non-differentiated) delayed-read ``h``."""
+    n = v.shape[0]
+    g = lambda v_: f(v_, p, h)  # close over p, h; differentiate w.r.t. v only
     (f_vals, q_vals), (dfs, dqs) = jax.vmap(lambda e: jax.jvp(g, (v,), (e,)))(jnp.eye(n))
     return (f_vals[0], q_vals[0]), (dfs.T, dqs.T)
 
@@ -258,6 +336,26 @@ def _primal_and_jac_complex(
     return primal, jac_r, jac_i
 
 
+def _primal_and_jac_complex_hist(
+    f, vr: Array, vi: Array, p: Array, h: Array
+) -> tuple[
+    tuple[Array, Array, Array, Array],
+    tuple[Array, Array, Array, Array],
+    tuple[Array, Array, Array, Array],
+]:
+    """Same as :func:`_primal_and_jac_complex`, with a fixed (non-differentiated) delayed-read ``h``."""
+    n = vr.shape[0]
+    zeros_vr = jnp.zeros_like(vr)
+    zeros_vi = jnp.zeros_like(vi)
+    g = lambda vr_, vi_: f(vr_, vi_, p, h)  # close over p, h; differentiate w.r.t. vr, vi only
+    (fr_s, fi_s, qr_s, qi_s), (dfr_r, dfi_r, dqr_r, dqi_r) = jax.vmap(lambda e: jax.jvp(g, (vr, vi), (e, zeros_vi)))(jnp.eye(n))
+    _, (dfr_i, dfi_i, dqr_i, dqi_i) = jax.vmap(lambda e: jax.jvp(g, (vr, vi), (zeros_vr, e)))(jnp.eye(n))
+    primal = (fr_s[0], fi_s[0], qr_s[0], qi_s[0])
+    jac_r = (dfr_r.T, dfi_r.T, dqr_r.T, dqi_r.T)
+    jac_i = (dfr_i.T, dfi_i.T, dqr_i.T, dqi_i.T)
+    return primal, jac_r, jac_i
+
+
 def assemble_system_real(
     y_guess: Array,
     component_groups: dict,
@@ -265,6 +363,8 @@ def assemble_system_real(
     dt: float,
     source_scale: float = 1.0,
     alpha: float = 1.0,
+    hist_t: Array | None = None,
+    hist_y: Array | None = None,
 ) -> tuple[Array, Array, Array]:
     """Assemble the residual vectors and effective Jacobian values for a real system.
 
@@ -348,9 +448,15 @@ def assemble_system_real(
             vals_list.append(j_eff.reshape(-1))
             continue
 
-        physics_at_t1 = functools.partial(_real_physics, group=group, t1=t1)
-
-        (f_l, q_l), (df_l, dq_l) = jax.vmap(functools.partial(_primal_and_jac_real, physics_at_t1))(v_locs, params)
+        if group.has_delay and hist_t is not None:
+            hist_locs = _real_hist_locs(group, params, t1, dt, hist_t, hist_y)
+            physics_at_t1 = functools.partial(_real_physics_hist, group=group, t1=t1)
+            (f_l, q_l), (df_l, dq_l) = jax.vmap(
+                functools.partial(_primal_and_jac_real_hist, physics_at_t1)
+            )(v_locs, params, hist_locs)
+        else:
+            physics_at_t1 = functools.partial(_real_physics, group=group, t1=t1)
+            (f_l, q_l), (df_l, dq_l) = jax.vmap(functools.partial(_primal_and_jac_real, physics_at_t1))(v_locs, params)
 
         total_f = total_f.at[group.eq_indices].add(f_l)
         total_q = total_q.at[group.eq_indices].add(q_l)
@@ -581,6 +687,8 @@ def assemble_residual_only_real(
     component_groups: dict,
     t1: float,
     dt: float,
+    hist_t: Array | None = None,
+    hist_y: Array | None = None,
 ) -> tuple[Array, Array]:
     """Assemble the residual vectors for a real system, without computing the Jacobian.
 
@@ -594,9 +702,12 @@ def assemble_residual_only_real(
         component_groups: Compiled component groups returned by
             :func:`compile_netlist`, keyed by group name.
         t1: Time at which the system is being evaluated.
-        dt: Unused; present for signature symmetry with
-            :func:`assemble_system_real` so the two functions are
-            interchangeable at call sites.
+        dt: Present for signature symmetry with :func:`assemble_system_real`
+            so the two functions are interchangeable at call sites. Only
+            used to guard ``tau >= dt`` for groups with delayed components.
+        hist_t: Accepted-step sample times for delayed reads, or ``None``
+            if the circuit has no delayed components.
+        hist_y: Accepted-step state samples for delayed reads, or ``None``.
 
     Returns:
         A two-tuple ``(total_f, total_q)`` where both arrays have shape
@@ -625,9 +736,12 @@ def assemble_residual_only_real(
 
         v = y_guess[group.var_indices]
 
-        physics_at_t1 = functools.partial(_real_physics, group=group, t1=t1)
-
-        f_l, q_l = jax.vmap(physics_at_t1)(v, group.params)
+        if group.has_delay and hist_t is not None:
+            hist_locs = _real_hist_locs(group, group.params, t1, dt, hist_t, hist_y)
+            f_l, q_l = jax.vmap(functools.partial(_real_physics_hist, group=group, t1=t1))(v, group.params, hist_locs)
+        else:
+            physics_at_t1 = functools.partial(_real_physics, group=group, t1=t1)
+            f_l, q_l = jax.vmap(physics_at_t1)(v, group.params)
 
         total_f = total_f.at[group.eq_indices].add(f_l)
         total_q = total_q.at[group.eq_indices].add(q_l)
@@ -642,6 +756,8 @@ def assemble_system_complex(
     dt: float,
     source_scale: float = 1.0,
     alpha: float = 1.0,
+    hist_t: Array | None = None,
+    hist_y: Array | None = None,
 ) -> tuple[Array, Array, Array]:
     """Assemble the residual vectors and effective Jacobian values for an unrolled complex system.
 
@@ -732,11 +848,17 @@ def assemble_system_complex(
             else group.params
         )
 
-        physics_split = functools.partial(_complex_physics, group=group, t1=t1)
-
-        (fr, fi, qr, qi), (dfr_r, dfi_r, dqr_r, dqi_r), (dfr_i, dfi_i, dqr_i, dqi_i) = jax.vmap(
-            functools.partial(_primal_and_jac_complex, physics_split)
-        )(v_r, v_i, params)
+        if group.has_delay and hist_t is not None:
+            hist_locs = _complex_hist_locs(group, params, t1, dt, hist_t, hist_y, half_size)
+            physics_split = functools.partial(_complex_physics_hist, group=group, t1=t1)
+            (fr, fi, qr, qi), (dfr_r, dfi_r, dqr_r, dqi_r), (dfr_i, dfi_i, dqr_i, dqi_i) = jax.vmap(
+                functools.partial(_primal_and_jac_complex_hist, physics_split)
+            )(v_r, v_i, params, hist_locs)
+        else:
+            physics_split = functools.partial(_complex_physics, group=group, t1=t1)
+            (fr, fi, qr, qi), (dfr_r, dfi_r, dqr_r, dqi_r), (dfr_i, dfi_i, dqr_i, dqi_i) = jax.vmap(
+                functools.partial(_primal_and_jac_complex, physics_split)
+            )(v_r, v_i, params)
 
         idx_r, idx_i = group.eq_indices, group.eq_indices + half_size
         total_f = total_f.at[idx_r].add(fr).at[idx_i].add(fi)
@@ -756,6 +878,8 @@ def assemble_residual_only_complex(
     component_groups: dict,
     t1: float,
     dt: float,
+    hist_t: Array | None = None,
+    hist_y: Array | None = None,
 ) -> tuple[Array, Array]:
     """Assemble the residual vectors for an unrolled complex system, without computing the Jacobian.
 
@@ -768,9 +892,12 @@ def assemble_residual_only_complex(
         component_groups: Compiled component groups returned by
             :func:`compile_netlist`, keyed by group name.
         t1: Time at which the system is being evaluated.
-        dt: Unused; present for signature symmetry with
-            :func:`assemble_system_complex` so the two functions are
-            interchangeable at call sites.
+        dt: Present for signature symmetry with :func:`assemble_system_complex`
+            so the two functions are interchangeable at call sites. Only used
+            to guard ``tau >= dt`` for groups with delayed components.
+        hist_t: Accepted-step sample times for delayed reads, or ``None``
+            if the circuit has no delayed components.
+        hist_y: Accepted-step state samples for delayed reads, or ``None``.
 
     Returns:
         A two-tuple ``(total_f, total_q)`` where both arrays have shape
@@ -802,9 +929,13 @@ def assemble_residual_only_complex(
 
         v_r, v_i = y_real[group.var_indices], y_imag[group.var_indices]
 
-        physics_split = functools.partial(_complex_physics, group=group, t1=t1)
-
-        fr, fi, qr, qi = jax.vmap(physics_split)(v_r, v_i, group.params)
+        if group.has_delay and hist_t is not None:
+            hist_locs = _complex_hist_locs(group, group.params, t1, dt, hist_t, hist_y, half_size)
+            physics_split = functools.partial(_complex_physics_hist, group=group, t1=t1)
+            fr, fi, qr, qi = jax.vmap(physics_split)(v_r, v_i, group.params, hist_locs)
+        else:
+            physics_split = functools.partial(_complex_physics, group=group, t1=t1)
+            fr, fi, qr, qi = jax.vmap(physics_split)(v_r, v_i, group.params)
 
         idx_r, idx_i = group.eq_indices, group.eq_indices + half_size
         total_f = total_f.at[idx_r].add(fr).at[idx_i].add(fi)

--- a/circulax/solvers/assembly.py
+++ b/circulax/solvers/assembly.py
@@ -256,6 +256,23 @@ def _group_tau(group, params, dt: float) -> Array:
     return eqxi.error_if(tau, tau < dt, msg)
 
 
+def min_active_tau(groups) -> Array | None:
+    """Smallest per-instance delay across all delay-having groups, or ``None`` if none.
+
+    Unlike :func:`_group_tau` (recomputed every Newton residual eval, since it
+    also carries the ``tau < dt`` runtime guard keyed to the *current* trial
+    step), this is meant to be computed once per solve -- group params are
+    fixed for the whole transient run. Used by ``setup_transient`` to
+    proactively clamp the adaptive step size (see
+    ``circulax.solvers.circuit_diffeq``) so that guard becomes a pure safety
+    net instead of something adaptive stepping can trip by surprise.
+    """
+    taus = [jnp.min(jax.vmap(g.tau_func)(g.params)) for g in groups.values() if getattr(g, "has_delay", False)]
+    if not taus:
+        return None
+    return jnp.min(jnp.stack(taus))
+
+
 def _real_hist_locs(group, params, t1: float, dt: float, hist_t: Array, hist_y: Array) -> Array:
     """Per-instance delayed local-var vector, real system layout."""
     tau = _group_tau(group, params, dt)

--- a/circulax/solvers/circuit_diffeq.py
+++ b/circulax/solvers/circuit_diffeq.py
@@ -138,6 +138,7 @@ def _circuit_loop(
     init_state: CircuitState,
     inner_while_loop,
     outer_while_loop,
+    min_tau: FloatScalarLike | None = None,
 ) -> CircuitState:
     """Core integration loop (no events, no dense output, no progress meter)."""
     # Pre-compute t1 - 100 ULPs for step clipping
@@ -230,6 +231,8 @@ def _circuit_loop(
 
         tprev = jnp.minimum(tprev, t1)
         tnext = _clip_to_end(tprev, tnext, t1, t1_clip_floor, keep_step)
+        if min_tau is not None:
+            tnext = jnp.minimum(tnext, tprev + min_tau)
 
         keep = lambda a, b: jnp.where(keep_step, a, b)
         y = jtu.tree_map(keep, y, state.y)
@@ -378,6 +381,7 @@ def circuit_diffeqsolve(
     throw: bool = True,
     checkpoints: int | None = None,
     record_history: bool = False,
+    min_tau: RealScalarLike | None = None,
 ) -> Solution:
     """Stripped-down :func:`diffrax.diffeqsolve` for circuit simulation.
 
@@ -398,6 +402,18 @@ def circuit_diffeqsolve(
     to use for fixed-delay lookups (see ``circulax.solvers.assembly``'s
     ``hist_t``/``hist_y`` parameters). No-op cost when ``False`` — the
     circuit has no delayed components.
+
+    ``min_tau``, when given, is a hard cap on the proposed step size
+    (``tnext - tprev``) at every iteration, so an adaptive
+    ``stepsize_controller`` can never propose ``dt`` larger than the smallest
+    active delay across the circuit's delayed components — mirroring how
+    ``t1`` is already clamped. This is a proactive optimization so
+    ``assembly.py``'s ``tau >= dt`` guard (the actually-enforced invariant)
+    should essentially never fire under adaptive control; it is a no-op when
+    ``None``. Gradient is intentionally stopped through ``min_tau`` itself
+    (it controls the step schedule, not a physical quantity feeding the
+    loss) — the delayed values read from the history buffer remain fully
+    differentiable.
     """
     # ------------------------------------------------------------------
     # dtype promotion for times (same logic as diffrax)
@@ -411,6 +427,15 @@ def circuit_diffeqsolve(
     t0 = jnp.asarray(t0, dtype=time_dtype)
     t1 = jnp.asarray(t1, dtype=time_dtype)
     dt0 = jnp.asarray(dt0, dtype=time_dtype)
+
+    if min_tau is not None:
+        # Schedule control, not a physical quantity feeding the loss -- stop
+        # gradient here, same convention diffrax's own PIDController uses for
+        # its step-size-control inputs (e.g. dt0). Shrink by a small relative
+        # margin so a reconstructed `tnext - tprev` can't round up past
+        # `min_tau` and trip assembly.py's strict `tau < dt` guard.
+        min_tau = jax.lax.stop_gradient(jnp.asarray(min_tau, dtype=time_dtype))
+        min_tau = min_tau * (1 - 100 * jnp.finfo(time_dtype).eps)
 
     # Cast save ts to the same dtype
     def _cast_ts(saveat):
@@ -489,6 +514,8 @@ def circuit_diffeqsolve(
     error_order = solver.error_order(terms)
     tnext, controller_state = stepsize_controller.init(terms, t0, t1, y0, dt0, args, solver.func, error_order)
     tnext = jnp.minimum(tnext, t1)
+    if min_tau is not None:
+        tnext = jnp.minimum(tnext, t0 + min_tau)
     solver_state = solver.init(terms, t0, tnext, y0, args)
 
     # ------------------------------------------------------------------
@@ -565,6 +592,7 @@ def circuit_diffeqsolve(
         init_state=init_state,
         inner_while_loop=inner_while_loop,
         outer_while_loop=outer_while_loop,
+        min_tau=min_tau,
     )
 
     # ------------------------------------------------------------------

--- a/circulax/solvers/circuit_diffeq.py
+++ b/circulax/solvers/circuit_diffeq.py
@@ -75,6 +75,12 @@ class CircuitState(eqx.Module):
     # Output buffers (updated via .at[].set() during the loop)
     save_state: PyTree[SaveState]
 
+    # Delay-history buffer (updated via .at[].set() during the loop).
+    # ``hist_t``/``hist_y`` are ``None`` when the circuit has no delayed
+    # components (``record_history=False``), so no buffer cost is paid.
+    hist_t: Array | None
+    hist_y: Array | None
+
 
 # ---------------------------------------------------------------------------
 # Buffer helpers (used by eqxi.while_loop for checkpointed AD)
@@ -94,10 +100,17 @@ def _is_none(x: Any) -> bool:
 
 
 def _outer_buffers(state: CircuitState):
-    """Return the mutable output buffers carried through the while-loop."""
+    """Return the mutable output buffers carried through the while-loop.
+
+    ``hist_t``/``hist_y`` are always included structurally (even when
+    ``None``, i.e. no delayed components) rather than conditionally omitted
+    by value — the ``buffers=`` selector must be a pure function of pytree
+    *structure*, not of leaf values, for equinox's checkpointed backward
+    pass to resolve buffer perturbations correctly.
+    """
     save_states = jtu.tree_leaves(state.save_state, is_leaf=_is_save_state)
     save_states = [s for s in save_states if _is_save_state(s)]
-    return [s.ts for s in save_states] + [s.ys for s in save_states]
+    return [s.ts for s in save_states] + [s.ys for s in save_states] + [state.hist_t, state.hist_y]
 
 
 def _inner_buffers(save_state: SaveState):
@@ -145,6 +158,19 @@ def _circuit_loop(
     init_state = eqx.tree_at(lambda s: s.save_state, init_state, save_state, is_leaf=_is_none)
 
     # ------------------------------------------------------------------
+    # Seed the delay-history buffer with (t0, y0) — delayed reads for
+    # query times before t0 clamp to the initial condition (jnp.interp's
+    # natural boundary behaviour against an ascending sample array).
+    # ------------------------------------------------------------------
+
+    if init_state.hist_t is not None:
+        hist_t0 = init_state.hist_t.at[0].set(t0)
+        hist_y0 = init_state.hist_y.at[0].set(init_state.y)
+        init_state = eqx.tree_at(
+            lambda s: (s.hist_t, s.hist_y), init_state, (hist_t0, hist_y0), is_leaf=_is_none,
+        )
+
+    # ------------------------------------------------------------------
     # While-loop condition
     # ------------------------------------------------------------------
 
@@ -156,13 +182,26 @@ def _circuit_loop(
     # ------------------------------------------------------------------
 
     def body_fun(state: CircuitState) -> CircuitState:
+        # Delayed components read history accepted up to (but not including)
+        # this step, i.e. the buffer as carried into this iteration — it is
+        # appended to further down, once the step below is accepted.
+        #
+        # `state.hist_t`/`state.hist_y` are `eqxi`'s internal `_Buffer` proxy
+        # (registered in `_outer_buffers` for efficient donation), not plain
+        # arrays -- ordinary jnp ops like `jnp.interp` don't accept them
+        # directly. Materialise via full-slice indexing (`_Buffer.__getitem__`
+        # unwraps one level) before handing them to the solver/assembly path;
+        # the write further below still operates on `state.hist_t`/`hist_y`
+        # themselves, so this doesn't disturb the buffer-donation machinery.
+        step_args = args if state.hist_t is None else (*args, state.hist_t[:], state.hist_y[:])
+
         # made_jump is always False for circuits (no discontinuities in input)
         (y, y_error, dense_info, solver_state, solver_result) = solver.step(
             terms,
             state.tprev,
             state.tnext,
             state.y,
-            args,
+            step_args,
             state.solver_state,
             False,  # made_jump – static, never traced
         )
@@ -203,6 +242,20 @@ def _circuit_loop(
         num_steps = state.num_steps + 1
         num_accepted_steps = state.num_accepted_steps + jnp.where(keep_step, 1, 0)
         num_rejected_steps = state.num_rejected_steps + jnp.where(keep_step, 0, 1)
+
+        # ------------------------------------------------------------------
+        # Record this accepted step in the delay-history buffer. Slot index
+        # is derived from the *pre-step* accepted-step count, so a rejected
+        # step retries the same slot; the where(...) makes the write a no-op
+        # (self-assignment) on rejection rather than clobbering with a stale
+        # duplicate point.
+        # ------------------------------------------------------------------
+        hist_t = state.hist_t
+        hist_y = state.hist_y
+        if hist_t is not None:
+            hist_idx = jnp.minimum(state.num_accepted_steps + 1, hist_t.shape[0] - 1)
+            hist_t = hist_t.at[hist_idx].set(jnp.where(keep_step, tprev, hist_t[hist_idx]))
+            hist_y = hist_y.at[hist_idx].set(jnp.where(keep_step, y, hist_y[hist_idx]))
 
         interpolator = solver.interpolation_cls(t0=state.tprev, t1=state.tnext, **dense_info)
 
@@ -253,6 +306,8 @@ def _circuit_loop(
             num_accepted_steps=num_accepted_steps,
             num_rejected_steps=num_rejected_steps,
             save_state=save_state,
+            hist_t=hist_t,
+            hist_y=hist_y,
         )
 
     # ------------------------------------------------------------------
@@ -322,6 +377,7 @@ def circuit_diffeqsolve(
     max_steps: int | None = 4096,
     throw: bool = True,
     checkpoints: int | None = None,
+    record_history: bool = False,
 ) -> Solution:
     """Stripped-down :func:`diffrax.diffeqsolve` for circuit simulation.
 
@@ -335,6 +391,13 @@ def circuit_diffeqsolve(
 
     ``checkpoints`` controls the number of binomial checkpoints used by
     ``RecursiveCheckpointAdjoint`` (``None`` = auto from ``max_steps``).
+
+    ``record_history``, when ``True``, allocates a ``(t, y)`` buffer of every
+    accepted step (sized ``max_steps + 1``, which must therefore be finite)
+    and threads it into ``args`` as ``(*args, hist_t, hist_y)`` for solvers
+    to use for fixed-delay lookups (see ``circulax.solvers.assembly``'s
+    ``hist_t``/``hist_y`` parameters). No-op cost when ``False`` — the
+    circuit has no delayed components.
     """
     # ------------------------------------------------------------------
     # dtype promotion for times (same logic as diffrax)
@@ -447,6 +510,19 @@ def circuit_diffeqsolve(
     save_state = jtu.tree_map(_allocate, saveat.subs, is_leaf=_is_subsaveat)
 
     # ------------------------------------------------------------------
+    # Allocate the delay-history buffer
+    # ------------------------------------------------------------------
+    if record_history:
+        if max_steps is None:
+            msg = "record_history=True requires a finite max_steps to size the delay-history buffer."
+            raise ValueError(msg)
+        hist_t = jnp.full(max_steps + 1, jnp.inf, dtype=time_dtype)
+        hist_y = jnp.full((max_steps + 1, *y0.shape), jnp.inf, dtype=y0.dtype)
+    else:
+        hist_t = None
+        hist_y = None
+
+    # ------------------------------------------------------------------
     # Build initial CircuitState
     # ------------------------------------------------------------------
     init_state = CircuitState(
@@ -460,6 +536,8 @@ def circuit_diffeqsolve(
         num_accepted_steps=0,
         num_rejected_steps=0,
         save_state=save_state,
+        hist_t=hist_t,
+        hist_y=hist_y,
     )
 
     # ------------------------------------------------------------------

--- a/circulax/solvers/transient.py
+++ b/circulax/solvers/transient.py
@@ -46,6 +46,22 @@ from circulax.solvers.linear import (
 )
 
 
+def _unpack_args(args):
+    """Unpack solver ``args`` into ``(component_groups, num_vars, hist_t, hist_y)``.
+
+    ``hist_t``/``hist_y`` are threaded in as a trailing pair by
+    ``circuit_diffeq.py``'s ``_circuit_loop`` only when the circuit has
+    delayed components (``record_history=True``); otherwise ``args`` is the
+    plain ``(component_groups, num_vars)`` 2-tuple and both are ``None``, so
+    ``assemble_system_real``/``assemble_system_complex`` skip the delayed-read
+    branch at zero cost.
+    """
+    if len(args) == 4:
+        return args
+    component_groups, num_vars = args
+    return component_groups, num_vars, None, None
+
+
 def _compute_history(component_groups, y_c, t, num_vars) -> ArrayLike:
     """Computes total charge Q at time t (Initial Condition)."""
     from circulax.solvers.assembly import _assemble_osdi_group, _is_osdi
@@ -97,7 +113,7 @@ class VectorizedTransientSolver(AbstractSolver):
         return (y0, 1.0)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         dt = t1 - t0
         y_prev_step, dt_prev = solver_state
 
@@ -111,10 +127,10 @@ class VectorizedTransientSolver(AbstractSolver):
 
         def newton_update_step(y, _) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, dt)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0, num_vars]
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, dt)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0]
 
             residual = total_f + (total_q - q_prev) / dt
@@ -174,7 +190,7 @@ class FactorizedTransientSolver(VectorizedTransientSolver):
     newton_max_steps: int = 100
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         dt = t1 - t0
         y_prev_step, dt_prev = solver_state
 
@@ -187,19 +203,19 @@ class FactorizedTransientSolver(VectorizedTransientSolver):
         q_prev = _compute_history(component_groups, y_c, t0, num_vars)
 
         if is_complex:
-            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, dt)
+            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, dt)
+            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(frozen_jac_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, dt)
+                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, dt)
+                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
 
             residual = total_f + (total_q - q_prev) / dt
             for idx in ground_indices:
@@ -256,7 +272,7 @@ class RefactoringTransientSolver(FactorizedTransientSolver):
     newton_max_steps: int = 20  # quadratic convergence; matches VectorizedTransientSolver default
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         dt = t1 - t0
         y_prev_step, dt_prev = solver_state
 
@@ -269,19 +285,19 @@ class RefactoringTransientSolver(FactorizedTransientSolver):
         q_prev = _compute_history(component_groups, y_c, t0, num_vars)
 
         if is_complex:
-            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, dt)
+            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, dt)
+            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(init_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, dt)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, dt)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, dt, hist_t=hist_t, hist_y=hist_y)
 
             residual = total_f + (total_q - q_prev) / dt
             for idx in ground_indices:
@@ -406,14 +422,14 @@ class BDF2VectorizedTransientSolver(VectorizedTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_c = y0[:num_vars] + 1j * y0[num_vars:] if is_complex else y0
         q0 = _compute_history(component_groups, y_c, t0, num_vars)
         return (y0, jnp.float64(jnp.inf), q0)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
@@ -421,10 +437,10 @@ class BDF2VectorizedTransientSolver(VectorizedTransientSolver):
 
         def newton_update_step(y, _) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0, num_vars]
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0]
 
             residual = make_residual(total_f, total_q)
@@ -463,33 +479,33 @@ class BDF2FactorizedTransientSolver(FactorizedTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_c = y0[:num_vars] + 1j * y0[num_vars:] if is_complex else y0
         q0 = _compute_history(component_groups, y_c, t0, num_vars)
         return (y0, jnp.float64(jnp.inf), q0)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
         y_pred, alpha, make_residual, new_state = _bdf2_preamble(y0, t0, h_n, solver_state, component_groups, num_vars, is_complex)
 
         if is_complex:
-            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(frozen_jac_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n)
+                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n)
+                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
 
             residual = make_residual(total_f, total_q)
             for idx in ground_indices:
@@ -527,33 +543,33 @@ class BDF2RefactoringTransientSolver(RefactoringTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_c = y0[:num_vars] + 1j * y0[num_vars:] if is_complex else y0
         q0 = _compute_history(component_groups, y_c, t0, num_vars)
         return (y0, jnp.float64(jnp.inf), q0)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
         y_pred, alpha, make_residual, new_state = _bdf2_preamble(y0, t0, h_n, solver_state, component_groups, num_vars, is_complex)
 
         if is_complex:
-            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(init_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
 
             residual = make_residual(total_f, total_q)
             for idx in ground_indices:
@@ -630,7 +646,7 @@ class SDIRK3VectorizedTransientSolver(VectorizedTransientSolver):
         return 3
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_prev_step, dt_prev = solver_state
@@ -650,9 +666,9 @@ class SDIRK3VectorizedTransientSolver(VectorizedTransientSolver):
         def _run_stage(y_init, q_hist, t_stage):
             def newton_update_step(y, _) -> jax.Array:
                 if is_complex:
-                    total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t_stage, h_n, alpha=alpha)
+                    total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t_stage, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 else:
-                    total_f, total_q, all_vals = assemble_system_real(y, component_groups, t_stage, h_n, alpha=alpha)
+                    total_f, total_q, all_vals = assemble_system_real(y, component_groups, t_stage, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 residual = total_f + (total_q - q_hist) / (_SDIRK3_G * h_n)
                 for idx in ground_indices:
                     residual = residual.at[idx].add(GROUND_STIFFNESS * y[idx])
@@ -709,7 +725,7 @@ class SDIRK3FactorizedTransientSolver(FactorizedTransientSolver):
         return 3
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_prev_step, dt_prev = solver_state
@@ -721,10 +737,10 @@ class SDIRK3FactorizedTransientSolver(FactorizedTransientSolver):
 
         # Factor J_eff ONCE at predictor — reused for all stages and iterations
         if is_complex:
-            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(frozen_jac_vals)
@@ -735,9 +751,9 @@ class SDIRK3FactorizedTransientSolver(FactorizedTransientSolver):
         def _run_stage(y_init, q_hist):
             def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
                 if is_complex:
-                    total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n)
+                    total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
                 else:
-                    total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n)
+                    total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
                 residual = total_f + (total_q - q_hist) / (_SDIRK3_G * h_n)
                 for idx in ground_indices:
                     residual = residual.at[idx].add(GROUND_STIFFNESS * y[idx])
@@ -789,7 +805,7 @@ class SDIRK3RefactoringTransientSolver(RefactoringTransientSolver):
         return 3
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
         y_prev_step, dt_prev = solver_state
@@ -800,10 +816,10 @@ class SDIRK3RefactoringTransientSolver(RefactoringTransientSolver):
         alpha = _SDIRK3_INV_G
 
         if is_complex:
-            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(init_vals)
@@ -814,9 +830,9 @@ class SDIRK3RefactoringTransientSolver(RefactoringTransientSolver):
         def _run_stage(y_init, q_hist, t_stage):
             def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
                 if is_complex:
-                    total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t_stage, h_n, alpha=alpha)
+                    total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t_stage, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 else:
-                    total_f, total_q, all_vals = assemble_system_real(y, component_groups, t_stage, h_n, alpha=alpha)
+                    total_f, total_q, all_vals = assemble_system_real(y, component_groups, t_stage, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 residual = total_f + (total_q - q_hist) / (_SDIRK3_G * h_n)
                 for idx in ground_indices:
                     residual = residual.at[idx].add(GROUND_STIFFNESS * y[idx])
@@ -877,12 +893,19 @@ class SDIRK3RefactoringTransientSolver(RefactoringTransientSolver):
 # α = α₀ ∈ [1, 5/3] for variable-step BDF2, α = 1/γ ≈ 2.29 for SDIRK3).
 
 
-def _compute_history_fq(component_groups, y_flat, t, num_vars, is_complex):
-    """Compute the (F, Q) residual pair at a given flat state vector — used by trap."""
+def _compute_history_fq(component_groups, y_flat, t, num_vars, is_complex, dt=0.0, hist_t=None, hist_y=None):
+    """Compute the (F, Q) residual pair at a given flat state vector — used by trap.
+
+    ``dt`` here is only used by delayed components to guard ``tau >= dt``
+    (see ``circulax.solvers.assembly``); it plays no role in the F/Q
+    computation itself, unlike the ``dt`` accepted by ``assemble_system_*``.
+    Callers with no real step size available (e.g. ``_trap_init``, evaluated
+    at ``t0`` before any step) pass ``0.0``, which makes the guard trivial.
+    """
     if is_complex:
-        total_f, total_q = assemble_residual_only_complex(y_flat, component_groups, t, 1.0)
+        total_f, total_q = assemble_residual_only_complex(y_flat, component_groups, t, dt, hist_t=hist_t, hist_y=hist_y)
     else:
-        total_f, total_q = assemble_residual_only_real(y_flat, component_groups, t, 1.0)
+        total_f, total_q = assemble_residual_only_real(y_flat, component_groups, t, dt, hist_t=hist_t, hist_y=hist_y)
     return total_f, total_q
 
 
@@ -907,13 +930,13 @@ def _trap_preamble(y0, t0, h_n, solver_state, component_groups, num_vars, is_com
     return y_pred, alpha, make_residual
 
 
-def _trap_init(component_groups, y0, t0, num_vars, is_complex):
+def _trap_init(component_groups, y0, t0, num_vars, is_complex, hist_t=None, hist_y=None):
     """Build the initial 4-tuple solver state for the trap solvers.
 
     Computes f0, q0 at y0 so the first step can use the cached values
     rather than recomputing them in ``_trap_preamble``.
     """
-    f0, q0 = _compute_history_fq(component_groups, y0, t0, num_vars, is_complex)
+    f0, q0 = _compute_history_fq(component_groups, y0, t0, num_vars, is_complex, hist_t=hist_t, hist_y=hist_y)
     return (y0, jnp.float64(jnp.inf), f0, q0)
 
 
@@ -932,12 +955,12 @@ class TrapVectorizedTransientSolver(VectorizedTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
-        return _trap_init(component_groups, y0, t0, num_vars, is_complex)
+        return _trap_init(component_groups, y0, t0, num_vars, is_complex, hist_t=hist_t, hist_y=hist_y)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
@@ -947,10 +970,10 @@ class TrapVectorizedTransientSolver(VectorizedTransientSolver):
 
         def newton_update_step(y, _) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0, num_vars]
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
                 ground_indices = [0]
 
             residual = make_residual(total_f, total_q)
@@ -970,7 +993,7 @@ class TrapVectorizedTransientSolver(VectorizedTransientSolver):
         y_error = y_next - y_pred
 
         # Cache f/q at the converged solution for the next step's preamble.
-        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex)
+        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex, dt=h_n, hist_t=hist_t, hist_y=hist_y)
         new_state = (y0, h_n, f_new, q_new)
 
         result = jax.lax.cond(
@@ -993,12 +1016,12 @@ class TrapFactorizedTransientSolver(FactorizedTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
-        return _trap_init(component_groups, y0, t0, num_vars, is_complex)
+        return _trap_init(component_groups, y0, t0, num_vars, is_complex, hist_t=hist_t, hist_y=hist_y)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
@@ -1007,19 +1030,19 @@ class TrapFactorizedTransientSolver(FactorizedTransientSolver):
         )
 
         if is_complex:
-            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, frozen_jac_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(frozen_jac_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n)
+                total_f, total_q = assemble_residual_only_complex(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n)
+                total_f, total_q = assemble_residual_only_real(y, component_groups, t1, h_n, hist_t=hist_t, hist_y=hist_y)
 
             residual = make_residual(total_f, total_q)
             for idx in ground_indices:
@@ -1039,7 +1062,7 @@ class TrapFactorizedTransientSolver(FactorizedTransientSolver):
         y_error = y_next - y_pred
 
         # Cache f/q at the converged solution for the next step's preamble.
-        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex)
+        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex, dt=h_n, hist_t=hist_t, hist_y=hist_y)
         new_state = (y0, h_n, f_new, q_new)
 
         result = jax.lax.cond(
@@ -1062,12 +1085,12 @@ class TrapRefactoringTransientSolver(RefactoringTransientSolver):
         return 2
 
     def init(self, terms, t0, t1, y0, args):
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         is_complex = getattr(self.linear_solver, "is_complex", False)
-        return _trap_init(component_groups, y0, t0, num_vars, is_complex)
+        return _trap_init(component_groups, y0, t0, num_vars, is_complex, hist_t=hist_t, hist_y=hist_y)
 
     def step(self, terms, t0, t1, y0, args, solver_state, options):  # noqa: ANN201, D102
-        component_groups, num_vars = args
+        component_groups, num_vars, hist_t, hist_y = _unpack_args(args)
         h_n = t1 - t0
         is_complex = getattr(self.linear_solver, "is_complex", False)
 
@@ -1076,19 +1099,19 @@ class TrapRefactoringTransientSolver(RefactoringTransientSolver):
         )
 
         if is_complex:
-            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_complex(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0, num_vars]
         else:
-            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha)
+            _, _, init_vals = assemble_system_real(y_pred, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             ground_indices = [0]
 
         numeric_handle = self.linear_solver.factor_jacobian(init_vals)
 
         def newton_update_step(y: jax.Array, _: Any) -> jax.Array:
             if is_complex:
-                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_complex(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
             else:
-                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha)
+                total_f, total_q, all_vals = assemble_system_real(y, component_groups, t1, h_n, alpha=alpha, hist_t=hist_t, hist_y=hist_y)
 
             residual = make_residual(total_f, total_q)
             for idx in ground_indices:
@@ -1112,7 +1135,7 @@ class TrapRefactoringTransientSolver(RefactoringTransientSolver):
         y_error = y_next - y_pred
 
         # Cache f/q at the converged solution for the next step's preamble.
-        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex)
+        f_new, q_new = _compute_history_fq(component_groups, y_next, t1, num_vars, is_complex, dt=h_n, hist_t=hist_t, hist_y=hist_y)
         new_state = (y0, h_n, f_new, q_new)
 
         result = jax.lax.cond(
@@ -1172,6 +1195,13 @@ def setup_transient(
         )
         raise RuntimeError(msg)
 
+    # Fixed time-delay support: gate the delay-history buffer behind whether
+    # any group actually has a delayed component, so undelayed circuits pay
+    # no cost. v1 requires ConstantStepSize (see circulax GitHub issue #2 —
+    # adaptive step size + delay is a documented follow-up, not implemented
+    # here).
+    has_delay = any(getattr(g, "has_delay", False) for g in groups.values())
+
     if transient_solver is None:
         # Pick the best Trap variant the linear solver supports.
         # Trap (2nd order, A-stable, zero numerical damping) is the right
@@ -1208,6 +1238,14 @@ def setup_transient(
         stepsize_controller = kwargs.pop("stepsize_controller", ConstantStepSize())
         checkpoints = kwargs.pop("checkpoints", None)
 
+        if has_delay and not isinstance(stepsize_controller, ConstantStepSize):
+            msg = (
+                "Circuits with delayed components (see circulax GitHub issue #2) "
+                "currently require ConstantStepSize; adaptive step size is a "
+                "follow-up, not yet implemented."
+            )
+            raise ValueError(msg)
+
         sol = circuit_diffeqsolve(
             terms=term,
             solver=solver,
@@ -1221,6 +1259,7 @@ def setup_transient(
             throw=throw,
             stepsize_controller=stepsize_controller,
             checkpoints=checkpoints,
+            record_history=has_delay,
         )
 
         return sol

--- a/circulax/solvers/transient.py
+++ b/circulax/solvers/transient.py
@@ -7,7 +7,7 @@ import diffrax
 import jax
 import jax.numpy as jnp
 import optimistix as optx
-from diffrax import AbstractSolver, ConstantStepSize
+from diffrax import AbstractAdaptiveStepSizeController, AbstractSolver, ConstantStepSize
 from jax.typing import ArrayLike
 
 from circulax.solvers.circuit_diffeq import circuit_diffeqsolve
@@ -37,6 +37,7 @@ from circulax.solvers.assembly import (
     assemble_residual_only_real,
     assemble_system_complex,
     assemble_system_real,
+    min_active_tau,
 )
 from circulax.solvers.linear import (
     DAMPING_EPS,
@@ -1181,6 +1182,14 @@ def setup_transient(
                 Defaults to a zero-value ODETerm.
             stepsize_controller (diffrax.AbstractStepSizeController, optional):
                 The step size controller. Defaults to `ConstantStepSize()`.
+                For circuits with delayed components, an adaptive controller
+                (e.g. `PIDController`) is automatically clamped so the
+                proposed step never exceeds the smallest active delay `tau`;
+                `ConstantStepSize` is left unclamped (an explicit
+                `dt0 > tau` still raises). Adaptive+delay circuits may need
+                a larger `max_steps` budget than constant-step ones, sized
+                against `(t1 - t0) / tau_min` as a floor, since the clamp
+                can force more steps than accuracy alone would require.
             **kwargs: Additional keyword arguments to pass directly to
                 `diffrax.diffeqsolve`.
 
@@ -1197,9 +1206,12 @@ def setup_transient(
 
     # Fixed time-delay support: gate the delay-history buffer behind whether
     # any group actually has a delayed component, so undelayed circuits pay
-    # no cost. v1 requires ConstantStepSize (see circulax GitHub issue #2 —
-    # adaptive step size + delay is a documented follow-up, not implemented
-    # here).
+    # no cost. Adaptive step-size controllers are supported (circulax GitHub
+    # issue #2, follow-up): the proposed step is proactively clamped to the
+    # smallest active tau (see `min_active_tau`/`min_tau` below) so
+    # assembly.py's `tau >= dt` guard stays a pure safety net rather than
+    # something adaptive stepping can trip mid-run. `ConstantStepSize`
+    # behavior is unchanged -- an explicit `dt0 > tau` still raises.
     has_delay = any(getattr(g, "has_delay", False) for g in groups.values())
 
     if transient_solver is None:
@@ -1238,13 +1250,12 @@ def setup_transient(
         stepsize_controller = kwargs.pop("stepsize_controller", ConstantStepSize())
         checkpoints = kwargs.pop("checkpoints", None)
 
-        if has_delay and not isinstance(stepsize_controller, ConstantStepSize):
-            msg = (
-                "Circuits with delayed components (see circulax GitHub issue #2) "
-                "currently require ConstantStepSize; adaptive step size is a "
-                "follow-up, not yet implemented."
-            )
-            raise ValueError(msg)
+        # Derive min_tau from the per-call component groups (args[0]), not the
+        # `groups` closed over above -- callers (e.g. gradient checks) may
+        # override `args` with perturbed params, and min_tau must track
+        # whatever is actually being simulated.
+        is_adaptive = isinstance(stepsize_controller, AbstractAdaptiveStepSizeController)
+        min_tau = min_active_tau(args[0]) if (has_delay and is_adaptive) else None
 
         sol = circuit_diffeqsolve(
             terms=term,
@@ -1260,6 +1271,7 @@ def setup_transient(
             stepsize_controller=stepsize_controller,
             checkpoints=checkpoints,
             record_history=has_delay,
+            min_tau=min_tau,
         )
 
         return sol

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -41,6 +41,7 @@ compile_netlist(net_dict, models) → [ComponentGroup, ...]
 | Spec | Status | What it covers |
 |------|--------|----------------|
 | [hierarchy.md](hierarchy.md) | **Done** | Hierarchical subcircuit composition — `RecursiveNetlist` support, netlist-level flattening, `Circuit`-as-subcircuit (V1, PR #39) |
+| [time-delay.md](time-delay.md) | **Done** | Frequency-domain delay line for AC/HB — `delay_line_fdomain` group-delay element (branch `feat-time-delay`) |
 | Physics — `circulax/components/` | **Planned** | <!-- FILL --> |
 | Topology — `circulax/compiler.py`, `circulax/netlist.py` | **Planned** | <!-- FILL --> |
 | Analysis — `circulax/solvers/` | **Planned** | <!-- FILL --> |

--- a/specs/overview.md
+++ b/specs/overview.md
@@ -41,7 +41,8 @@ compile_netlist(net_dict, models) → [ComponentGroup, ...]
 | Spec | Status | What it covers |
 |------|--------|----------------|
 | [hierarchy.md](hierarchy.md) | **Done** | Hierarchical subcircuit composition — `RecursiveNetlist` support, netlist-level flattening, `Circuit`-as-subcircuit (V1, PR #39) |
-| [time-delay.md](time-delay.md) | **Done** | Frequency-domain delay line for AC/HB — `delay_line_fdomain` group-delay element (branch `feat-time-delay`) |
+| [time-delay.md](time-delay.md) | **Done** | Time delay for AC/HB and transient — `delay_line_fdomain` + `OpticalDelayLine` with DDE history buffer (branch `feat-time-delay`) |
+| [vector-fitting.md](vector-fitting.md) | **Done** | S-parameter vector fitting with delay de-embedding — `rational_component`, `rational_fdomain_component`, `rational_delay_component` (branch `feat-time-delay`) |
 | Physics — `circulax/components/` | **Planned** | <!-- FILL --> |
 | Topology — `circulax/compiler.py`, `circulax/netlist.py` | **Planned** | <!-- FILL --> |
 | Analysis — `circulax/solvers/` | **Planned** | <!-- FILL --> |

--- a/specs/time-delay.md
+++ b/specs/time-delay.md
@@ -1,0 +1,170 @@
+# Frequency-Domain Delay Line for AC/HB Analysis
+
+## Overview
+
+| Property | Value |
+|----------|-------|
+| Description | Pure group-delay element for AC sweep and harmonic balance |
+| SPICE Equivalent | Ideal lossless transmission line (frequency domain only) |
+| Approach | `exp(-j 2π f τ)` on S-matrix off-diagonals, converted to Y via `s_to_y` |
+| Analysis types | AC sweep, harmonic balance |
+| Transient | Not supported — fdomain components raise at `setup_transient()` time |
+| Status | Complete (branch `feat-time-delay`) |
+
+## Problem Statement
+
+Photonic circuits require modeling signal propagation delay through waveguides.
+For AC and harmonic-balance analysis, delay is a frequency-domain concept: a
+delay of `τ` seconds multiplies each S-parameter off-diagonal by `exp(-j 2π f τ)`.
+
+The key insight is that `f` in an `@fdomain_component` is the **modulation/signal
+frequency** (e.g. 1 GHz for an AC sweep), not the optical carrier frequency
+(~229 THz at 1310 nm). Carrier-phase effects (`neff`, `wavelength_nm`) belong in
+the wavelength-domain `OpticalWaveguide` and are intentionally excluded from this
+component.
+
+### Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `@fdomain_component` decorator | Provides `Y(f)` admittance matrices stamped into `Y_total` at each frequency point — no netlist expansion |
+| No carrier phase | `f` = modulation frequency, not optical carrier; `neff`/`wavelength_nm` are wavelength-domain concepts |
+| `s_to_y` conversion | Reuses existing S→Y infrastructure; consistent with `OpticalWaveguide` |
+| No transient support | Fdomain components are AC/HB-only by design; `setup_transient()` raises `RuntimeError` if any group has `is_fdomain=True` |
+
+---
+
+## Specification
+
+### Component: `delay_line_fdomain`
+
+```python
+@fdomain_component(ports=("p1", "p2"))
+def delay_line_fdomain(
+    f: float,
+    length_um: float = 100.0,
+    loss_dB_cm: float = 1.0,
+    n_group: float = 4.0,
+) -> jnp.ndarray:
+    c_um_per_s = 2.99792458e14
+    loss_val = loss_dB_cm * (length_um / 10000.0)
+    T_mag = 10.0 ** (-loss_val / 20.0)
+    tau = (length_um * n_group) / c_um_per_s
+    T = T_mag * jnp.exp(-1j * 2.0 * jnp.pi * f * tau)
+    S = jnp.array([[0.0, T], [T, 0.0]], dtype=jnp.complex128)
+    return s_to_y(S)
+```
+
+### Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `f` | Modulation frequency in Hz (supplied by the AC/HB solver) | — |
+| `length_um` | Waveguide length in micrometres | `100.0` |
+| `loss_dB_cm` | Propagation loss in dB/cm | `1.0` |
+| `n_group` | Group refractive index; sets delay via `τ = length_um · n_group / c` | `4.0` |
+
+### S-parameter round-trip
+
+For an fdomain Y-matrix component, the AC sweep solver stamps `Y_fdomain(f)` directly
+into the nodal admittance matrix. The S→Y→stamp→solve→S round-trip yields:
+
+```
+S21 = T_mag · exp(-j · 2π · f · τ)
+```
+
+Note: no factor-of-2 on `T_mag`. The `s_to_y` Y-matrix stamp gives `S21 = T` (identity
+round-trip), unlike VCVS-style components where the constraint structure gives `S21 = 2T`.
+
+### Usage
+
+```python
+from circulax import compile_netlist
+from circulax.components.photonic import delay_line_fdomain
+from circulax.solvers import analyze_circuit, setup_ac_sweep
+
+models_map = {"delay": delay_line_fdomain, "ground": lambda: 0}
+net_dict = {
+    "instances": {
+        "GND": {"component": "ground"},
+        "WG1": {"component": "delay", "settings": {"length_um": 500.0, "n_group": 4.0}},
+    },
+    "connections": {},
+    "ports": {"in": "WG1,p1", "out": "WG1,p2"},
+}
+
+groups, num_vars, pmap = compile_netlist(net_dict, models_map)
+solver = analyze_circuit(groups, num_vars, backend="dense", is_complex=True)
+y_dc = solver.solve_dc(groups, jnp.zeros(num_vars * 2, dtype=jnp.float64))
+
+port_nodes = [pmap["WG1,p1"], pmap["WG1,p2"]]
+run_ac = setup_ac_sweep(groups, num_vars, port_nodes, z0=1.0, is_complex=True)
+S = run_ac(y_dc, jnp.linspace(1e9, 100e9, 50))
+```
+
+---
+
+## Implementation Files
+
+| File | Change |
+|------|--------|
+| `circulax/components/photonic.py` | `delay_line_fdomain` component; removed `OpticalDelayLine` |
+| `circulax/components/__init__.py` | Exports `delay_line_fdomain` |
+| `tests/test_delay.py` | `test_delay_line_fdomain_ac_sweep` — validates S21 magnitude and phase against analytic formula |
+
+### Removed files / code (old transient delay machinery)
+
+The following infrastructure was removed as part of the pivot from transient
+history-buffer delays to the cleaner fdomain approach:
+
+| File | Removed |
+|------|---------|
+| `circulax/components/base_component.py` | `hist` argument detection, `@Component.delay` decorator, `_has_delay` flag, `tau_of`, `_tau_cell`, `_register_delay`, `_resolve_tau`, `has_hist_arg` |
+| `circulax/compiler.py` | `has_delay` and `tau_func` fields on `ComponentGroup` |
+| `circulax/solvers/assembly.py` | `_interp_delayed`, `_group_tau`, `min_active_tau`, `assemble_delay_gc_real/complex/complex_2n`, delayed physics/Jacobian wrappers, `hist_t`/`hist_y` params on all `assemble_*` functions |
+| `circulax/solvers/circuit_diffeq.py` | `CircuitState.hist_t`/`hist_y` fields, buffer allocation, seed/write/clamp logic, `record_history`/`min_tau` params |
+| `circulax/solvers/transient.py` | `has_delay` detection, `min_tau` computation, `record_history` kwarg, delay warning callback, `hist_t`/`hist_y` params on helper functions |
+| `circulax/solvers/ac_sweep.py` | `assemble_delay_gc_*` imports, `has_delay`/`delay_data` variables, per-frequency delay-phase contribution loops |
+| `tests/test_delay.py` | 8 old transient delay tests (`test_delay_line_matches_analytic_shift`, gradient tests, adaptive tests, `OpticalDelayLine` AC sweep test, etc.) |
+
+---
+
+## Test Matrix
+
+| Test | Verification |
+|------|-------------|
+| `test_delay_line_fdomain_ac_sweep` | S21 magnitude matches `T_mag` within 1e-6; S21 phase matches `-2πfτ` within 1e-6 rad |
+
+---
+
+## Known Limitations
+
+### 1. No transient delay support — **By design**
+
+Fdomain components cannot be used in transient simulation. `setup_transient()` raises
+`RuntimeError` if any group has `is_fdomain=True`. Transient delay would require
+re-implementing the history-buffer machinery that was removed, or upstream diffrax DDE
+support.
+
+### 2. Near-lossless conditioning — **Inherited from `s_to_y`**
+
+When `T_mag ≈ 1`, the S-matrix eigenvalue approaches -1 and `(I + S)` becomes
+near-singular, causing `s_to_y` to produce large Y-matrix entries. This is the same
+limitation as `OpticalWaveguide` and other S-matrix-based components. Workaround: use
+a small nonzero `loss_dB_cm`.
+
+### 3. No state-dependent delays — **By design**
+
+Delay `τ` is computed from component parameters (`length_um`, `n_group`), not from the
+circuit state. State-dependent delays would require DDE machinery.
+
+---
+
+## Verification
+
+All tests pass. No regressions in the full suite.
+
+```bash
+pytest tests/test_delay.py -v   # 1 passed (3.7s)
+pytest tests/ -v                # 269 passed, 16 skipped, 0 failures (115s)
+```

--- a/specs/time-delay.md
+++ b/specs/time-delay.md
@@ -13,23 +13,27 @@
 ## Problem Statement
 
 Photonic circuits require modeling signal propagation delay through waveguides.
-For AC and harmonic-balance analysis, delay is a frequency-domain concept: a
-delay of `τ` seconds multiplies each S-parameter off-diagonal by `exp(-j 2π f τ)`.
+Two complementary approaches coexist:
+
+1. **Frequency domain** (AC/HB): delay is `exp(-j 2π f τ)` on S21, converted to Y.
+2. **Transient** (time domain): delay is a DDE with history buffer — the solver
+   reads delayed state `y(t-τ)` via interpolation of a ring buffer.
 
 The key insight is that `f` in an `@fdomain_component` is the **modulation/signal
 frequency** (e.g. 1 GHz for an AC sweep), not the optical carrier frequency
 (~229 THz at 1310 nm). Carrier-phase effects (`neff`, `wavelength_nm`) belong in
-the wavelength-domain `OpticalWaveguide` and are intentionally excluded from this
-component.
+the wavelength-domain `OpticalWaveguide` and are intentionally excluded from these
+components.
 
 ### Design decisions
 
 | Decision | Rationale |
 |----------|-----------|
+| Two component types | `delay_line_fdomain` for AC/HB; `OpticalDelayLine` for transient — each uses the natural formulation for its analysis type |
 | `@fdomain_component` decorator | Provides `Y(f)` admittance matrices stamped into `Y_total` at each frequency point — no netlist expansion |
+| `@component` with `hist` arg | Transient delay uses the `hist` mechanism: `_has_delay=True` triggers history buffer allocation in the solver |
 | No carrier phase | `f` = modulation frequency, not optical carrier; `neff`/`wavelength_nm` are wavelength-domain concepts |
 | `s_to_y` conversion | Reuses existing S→Y infrastructure; consistent with `OpticalWaveguide` |
-| No transient support | Fdomain components are AC/HB-only by design; `setup_transient()` raises `RuntimeError` if any group has `is_fdomain=True` |
 
 ---
 
@@ -107,24 +111,15 @@ S = run_ac(y_dc, jnp.linspace(1e9, 100e9, 50))
 
 | File | Change |
 |------|--------|
-| `circulax/components/photonic.py` | `delay_line_fdomain` component; removed `OpticalDelayLine` |
-| `circulax/components/__init__.py` | Exports `delay_line_fdomain` |
-| `tests/test_delay.py` | `test_delay_line_fdomain_ac_sweep` — validates S21 magnitude and phase against analytic formula |
-
-### Removed files / code (old transient delay machinery)
-
-The following infrastructure was removed as part of the pivot from transient
-history-buffer delays to the cleaner fdomain approach:
-
-| File | Removed |
-|------|---------|
-| `circulax/components/base_component.py` | `hist` argument detection, `@Component.delay` decorator, `_has_delay` flag, `tau_of`, `_tau_cell`, `_register_delay`, `_resolve_tau`, `has_hist_arg` |
+| `circulax/components/photonic.py` | `delay_line_fdomain` (AC/HB) and `OpticalDelayLine` (transient) components |
+| `circulax/components/base_component.py` | `hist` argument detection, `@Component.delay` decorator, `_has_delay` flag |
 | `circulax/compiler.py` | `has_delay` and `tau_func` fields on `ComponentGroup` |
-| `circulax/solvers/assembly.py` | `_interp_delayed`, `_group_tau`, `min_active_tau`, `assemble_delay_gc_real/complex/complex_2n`, delayed physics/Jacobian wrappers, `hist_t`/`hist_y` params on all `assemble_*` functions |
-| `circulax/solvers/circuit_diffeq.py` | `CircuitState.hist_t`/`hist_y` fields, buffer allocation, seed/write/clamp logic, `record_history`/`min_tau` params |
-| `circulax/solvers/transient.py` | `has_delay` detection, `min_tau` computation, `record_history` kwarg, delay warning callback, `hist_t`/`hist_y` params on helper functions |
-| `circulax/solvers/ac_sweep.py` | `assemble_delay_gc_*` imports, `has_delay`/`delay_data` variables, per-frequency delay-phase contribution loops |
-| `tests/test_delay.py` | 8 old transient delay tests (`test_delay_line_matches_analytic_shift`, gradient tests, adaptive tests, `OpticalDelayLine` AC sweep test, etc.) |
+| `circulax/solvers/assembly.py` | `_interp_delayed`, `_group_tau`, `min_active_tau`, delayed-read branches |
+| `circulax/solvers/circuit_diffeq.py` | `CircuitState.hist_t`/`hist_y` fields, buffer allocation/seed/write |
+| `circulax/solvers/transient.py` | `has_delay` detection, `min_tau` computation, history threading |
+| `circulax/solvers/ac_sweep.py` | Complex-mode S-parameter extraction fix for 2N real-block form |
+| `circulax/components/__init__.py` | Exports `delay_line_fdomain`, `OpticalDelayLine` |
+| `tests/test_delay.py` | 8 tests (7 transient + 1 fdomain) |
 
 ---
 
@@ -133,17 +128,23 @@ history-buffer delays to the cleaner fdomain approach:
 | Test | Verification |
 |------|-------------|
 | `test_delay_line_fdomain_ac_sweep` | S21 magnitude matches `T_mag` within 1e-6; S21 phase matches `-2πfτ` within 1e-6 rad |
+| `test_delay_line_matches_analytic_shift` | Transient output at DUT port matches ideal delayed step |
+| `test_delay_line_gradient` | `jax.grad` through delay line produces finite, nonzero gradient |
+| `test_optical_delay_line_matches_analytic` | Phase-shifted output matches analytic expectation |
+| `test_delay_gradient_length` | Gradient of output w.r.t. waveguide length is finite |
+| `test_delay_adaptive_step_size` | Adaptive solver produces same result as fixed-step |
+| `test_delay_gradient_adaptive` | Gradient through adaptive solver is finite |
+| `test_optical_delay_line_ac_sweep` | AC sweep S21 matches analytic delay formula |
 
 ---
 
 ## Known Limitations
 
-### 1. No transient delay support — **By design**
+### 1. Fdomain components are AC/HB only
 
 Fdomain components cannot be used in transient simulation. `setup_transient()` raises
-`RuntimeError` if any group has `is_fdomain=True`. Transient delay would require
-re-implementing the history-buffer machinery that was removed, or upstream diffrax DDE
-support.
+`RuntimeError` if any group has `is_fdomain=True`. For transient delay, use
+`OpticalDelayLine` (transient `@component` with history buffer).
 
 ### 2. Near-lossless conditioning — **Inherited from `s_to_y`**
 
@@ -152,10 +153,17 @@ near-singular, causing `s_to_y` to produce large Y-matrix entries. This is the s
 limitation as `OpticalWaveguide` and other S-matrix-based components. Workaround: use
 a small nonzero `loss_dB_cm`.
 
-### 3. No state-dependent delays — **By design**
+### 3. No state-dependent delays
 
 Delay `τ` is computed from component parameters (`length_um`, `n_group`), not from the
-circuit state. State-dependent delays would require DDE machinery.
+circuit state. State-dependent delays would require DDE machinery beyond the current
+fixed-τ history buffer.
+
+### 4. Delay + rational composite is AC/HB only
+
+`rational_delay_component` (see [vector-fitting.md](vector-fitting.md)) creates an
+fdomain composite — it cannot be used in transient. For transient simulation of fitted
+S-parameter data, use `rational_component` alone and wire delay elements separately.
 
 ---
 
@@ -164,6 +172,6 @@ circuit state. State-dependent delays would require DDE machinery.
 All tests pass. No regressions in the full suite.
 
 ```bash
-pytest tests/test_delay.py -v   # 1 passed (3.7s)
-pytest tests/ -v                # 269 passed, 16 skipped, 0 failures (115s)
+pytest tests/test_delay.py -v   # 8 passed
+pytest tests/ -v                # 291 passed, 16 skipped, 0 failures
 ```

--- a/specs/time-delay.md
+++ b/specs/time-delay.md
@@ -1,14 +1,13 @@
-# Frequency-Domain Delay Line for AC/HB Analysis
+# Time Delay for Circuit Simulation
 
 ## Overview
 
 | Property | Value |
 |----------|-------|
-| Description | Pure group-delay element for AC sweep and harmonic balance |
-| SPICE Equivalent | Ideal lossless transmission line (frequency domain only) |
-| Approach | `exp(-j 2π f τ)` on S-matrix off-diagonals, converted to Y via `s_to_y` |
-| Analysis types | AC sweep, harmonic balance |
-| Transient | Not supported — fdomain components raise at `setup_transient()` time |
+| Description | Group-delay modeling for waveguides and transmission lines |
+| SPICE Equivalent | Ideal lossless transmission line |
+| Approach | Fdomain: `exp(-j 2π f τ)` S-matrix; Transient: DDE history buffer |
+| Analysis types | AC sweep, harmonic balance, transient |
 | Status | Complete (branch `feat-time-delay`) |
 
 ## Problem Statement

--- a/specs/vector-fitting.md
+++ b/specs/vector-fitting.md
@@ -1,0 +1,142 @@
+# Vector Fitting of S-Parameters with Delay De-Embedding
+
+## Goal
+
+Convert frequency-domain S-parameter data into simulation-ready circulax components
+via rational approximation (AAA method), with group-delay de-embedding to reduce
+pole count for transmission-line-like data.
+
+## Context
+
+S-parameter data (from measurement or EM simulation) describes a linear N-port over
+frequency. To simulate this network in transient (time domain), the data must be
+converted to a rational transfer function that maps onto circulax's DAE formulation.
+
+For transmission lines, the raw S-parameters contain a large linear phase ramp from
+propagation delay. Fitting this directly requires 40-100+ poles. By de-embedding the
+group delay first, the smooth remainder fits with ~5 poles — a massive reduction that
+shrinks the Jacobian (cost scales as O(poles²)) and improves numerical conditioning.
+
+The fitting engine is **vfitax** (separate repo, branch `scipy-aaa`). Circulax
+consumes the fitted `SSModel` to create simulation-ready components.
+
+### Key formulas
+
+| Formula | Description |
+|---------|-------------|
+| `H(s) = C·diag(1/(s-A))·B + D + s·E` | State-space transfer function |
+| `τ = -dφ(S21)/dω` | Group delay extraction (LS phase slope) |
+| `S' = P·S·P` where `P = diag(exp(+jωτ/2))` | Reference-plane de-embedding |
+| `S_full = P·S·P` where `P = diag(exp(-jπfτ))` | Reference-plane re-embedding |
+| `Y = (I-S)(z0·S + z0*·I)⁻¹` | Kurokawa S-to-Y conversion |
+
+### Design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| AAA method (not VF iteration) | Automatic pole selection, fast, no initial pole guess needed |
+| De-embed before fitting | Removes linear phase → fewer poles, better conditioning of `s_to_y` |
+| Passivity on de-embedded Y | `σ_max(PSP) = σ_max(S)` for unitary P, so passivity transfers to full cascade |
+| `is_complex=True` required | Real-pair block form (`_ss_to_real_pairs`) not yet implemented; all rational circuits use complex-doubled path |
+
+---
+
+## Acceptance criteria
+
+- [x] `fit_with_delay` returns SSModel + tau with ≥5× pole reduction vs raw fit
+- [x] Round-trip: `embed(deembed(S)) == S` to machine precision
+- [x] Over-estimated delay triggers pole-flip tripwire
+- [x] `rational_component` AC sweep matches `rational_fdomain_component` to 1e-8
+- [x] AC sweep Y matches independent pole-residue oracle to 1e-6
+- [x] DC response: `i_port = H(0) @ v` from consistent (v, x) state
+- [x] Transient: step response settles to correct divider voltage (rtol=0.01)
+- [x] `rational_delay_component` S21 group delay matches τ (rtol=0.03)
+- [x] `rational_delay_component` with τ=0 matches `rational_fdomain_component`
+- [x] Asymmetric delay: S11/S22 group delays match τ1/τ2 independently
+
+---
+
+## Components
+
+| Component | Description | Repo | Depends on |
+|-----------|-------------|------|------------|
+| S-param pipeline | `extract_group_delay`, `deembed_delay`, `embed_delay`, `fit_with_delay` | vfitax | — |
+| `rational_component` | Time-domain DAE component from SSModel | circulax | S-param pipeline |
+| `rational_fdomain_component` | Fdomain oracle from SSModel (test reference) | circulax | — |
+| `rational_delay_component` | Fdomain composite: delay + rational cascade | circulax | `rational_component` |
+
+---
+
+## Delegation map
+
+| Component | File scope | Constraints |
+|-----------|------------|-------------|
+| S-param pipeline | `vfitax/sparam.py`, `vfitax/tests/unit/test_sparam.py` | Duplicate `s_to_y` (5 lines) to avoid cross-dep |
+| Rational factories | `circulax/components/rational.py`, `tests/test_rational.py` | Must use `is_complex=True`; `z0` not differentiable |
+| Exports | `circulax/__init__.py`, `circulax/components/__init__.py` | — |
+
+---
+
+## Implementation notes
+
+### SSModel → DAE stamp
+
+The state-space model maps directly to circulax's `F(y) + dQ/dt = 0`:
+
+```
+Port i:   f[port_i] = (C @ x + D @ v)_i       q[port_i] = (E @ v)_i
+State j:  f[x_j]    = -(A_j·x_j + (B @ v)_j)  q[x_j]    = x_j
+```
+
+The linearized `G + jωC` block is `[[D+jωE, C], [-B, jωI-A]]`, whose Schur
+complement gives exactly `H(jω)`.
+
+### Port termination subtraction
+
+AC sweep Y = s_to_y(S, z0) includes port shunt resistors. To recover the DUT's
+Y-parameters: `Y_DUT = Y_circuit - I/z0`. This is needed for oracle comparison
+tests but not for normal simulation.
+
+### circulax `s_to_y` default z0
+
+circulax uses `z0=1.0+1e-12j` (photonic convention) while vfitax uses `z0=50.0`.
+Explicit `z0=50.0` is required when converting electrical S-parameters.
+
+### Delay over-estimation guard
+
+If the LS phase slope over-estimates τ (e.g. from dispersion), the de-embedded
+remainder approximates `exp(+jωδ)` — a non-causal advance. AAA fits this with
+RHP poles, and `_collect_poles` flips them to LHP, destroying the fit. The
+`fit_with_delay` metadata includes `pole_flips` count as a tripwire.
+
+### Real-pair block form (future)
+
+`_ss_to_real_pairs` would convert conjugate pole pairs to 2×2 real blocks,
+halving system size for electrical circuits. Currently all rational circuits
+pay 2× via `is_complex=True`. Documented as a future optimization.
+
+---
+
+## Implementation files
+
+| File | Repo | Action |
+|------|------|--------|
+| `vfitax/sparam.py` | vfitax | New — delay de-embedding and S-parameter fit pipeline |
+| `vfitax/tests/unit/test_sparam.py` | vfitax | New — round-trip, pole reduction, tripwire tests |
+| `circulax/components/rational.py` | circulax | New — SSModel → component factories |
+| `tests/test_rational.py` | circulax | New — 15 tests (oracle, DC, transient, delay phase-slope) |
+| `circulax/components/__init__.py` | circulax | Updated exports |
+| `circulax/__init__.py` | circulax | Updated imports |
+
+---
+
+## Verification
+
+```bash
+# vfitax (scipy-aaa branch)
+pytest vfitax/tests/ -v   # 95 passed
+
+# circulax (feat-time-delay worktree)
+pytest tests/test_rational.py -v   # 15 passed
+pytest tests/ -v                   # 291 passed, 16 skipped, 0 failures
+```

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -370,3 +370,71 @@ def test_undelayed_circuit_unaffected(simple_lrc_netlist):
         max_steps=5000, throw=True,
     )
     assert jnp.all(jnp.isfinite(sol.ys))
+
+
+# ===========================================================================
+# Frequency-domain delay line (AC/HB)
+# ===========================================================================
+
+
+def test_delay_line_fdomain_ac_sweep():
+    """AC sweep with delay_line_fdomain reproduces S21 = T_mag*exp(-j*2*pi*f*tau).
+
+    This fdomain component is a pure group-delay element with no wavelength
+    parameters.  The analytic reference has no carrier-phase term — only loss
+    and delay.
+    """
+    from circulax.components.photonic import delay_line_fdomain
+    from circulax.solvers import setup_ac_sweep
+
+    tau = 1e-12
+    length_um = tau * _C_UM_PER_S / _N_GROUP
+    loss_dB_cm = 2.0
+
+    models_map = {
+        "delay": delay_line_fdomain,
+        "ground": lambda: 0,
+    }
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "WG1": {
+                "component": "delay",
+                "settings": {
+                    "length_um": length_um,
+                    "n_group": _N_GROUP,
+                    "loss_dB_cm": loss_dB_cm,
+                },
+            },
+        },
+        "connections": {},
+        "ports": {"in": "WG1,p1", "out": "WG1,p2"},
+    }
+    groups, num_vars, pmap = compile_netlist(net_dict, models_map)
+    solver = analyze_circuit(groups, num_vars, backend="dense", is_complex=True)
+    y_dc = solver.solve_dc(groups, jnp.zeros(num_vars * 2, dtype=jnp.float64))
+
+    port_nodes = [pmap["WG1,p1"], pmap["WG1,p2"]]
+    z0 = 1.0
+    run_ac = setup_ac_sweep(groups, num_vars, port_nodes, z0=z0, is_complex=True)
+
+    freqs = jnp.linspace(1e9, 500e9, 20)
+    S = run_ac(y_dc, freqs)
+
+    assert S.shape == (len(freqs), 2, 2)
+    assert jnp.all(jnp.isfinite(S))
+
+    S21 = S[:, 1, 0]
+
+    loss_val = loss_dB_cm * (length_um / 10000.0)
+    T_mag = 10.0 ** (-loss_val / 20.0)
+    omega = 2.0 * jnp.pi * freqs
+    S21_analytic = T_mag * jnp.exp(-1j * omega * tau)
+
+    assert jnp.allclose(jnp.abs(S21), jnp.abs(S21_analytic), atol=1e-6), (
+        f"Magnitude error: {jnp.max(jnp.abs(jnp.abs(S21) - jnp.abs(S21_analytic))):.2e}"
+    )
+    phase_err = jnp.angle(S21 * jnp.conj(S21_analytic))
+    assert jnp.max(jnp.abs(phase_err)) < 1e-6, (
+        f"Phase error: {jnp.max(jnp.abs(phase_err)):.2e} rad"
+    )

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -8,8 +8,12 @@ Verifies:
   - Gradients w.r.t. a delay-driving parameter (``length_um``) match finite
     differences through the checkpointed adjoint.
   - The ``tau >= dt`` guard rejects delays shorter than the step size.
-  - Adaptive step-size controllers are rejected for delayed circuits (v1
-    requires ConstantStepSize).
+  - Adaptive step-size controllers (e.g. ``PIDController``) are supported for
+    delayed circuits: the proposed step is proactively clamped to the
+    smallest active ``tau``, matching the analytic shift and a
+    ``ConstantStepSize`` run, with gradients still matching finite
+    differences. ``ConstantStepSize`` itself remains unclamped -- an
+    explicit ``dt0 > tau`` still raises.
 """
 
 import diffrax
@@ -212,21 +216,143 @@ def test_delay_shorter_than_dt_raises():
         )
 
 
-def test_delay_requires_constant_step_size(two_delay_lines_netlist):
-    """Adaptive step-size controllers are rejected for delayed circuits (v1 limitation)."""
+def test_delay_line_adaptive_matches_analytic_shift(two_delay_lines_netlist):
+    """PIDController + delay must match the same analytic shift as ConstantStepSize.
+
+    The proposed step is proactively clamped to the smallest active tau (here
+    tau1=1e-12), so ``num_accepted_steps`` should be well above the bare
+    minimum ``(t1 - t0) / max(tau1, tau2)`` -- confirming the clamp is
+    actually exercised rather than PIDController's own tolerances happening
+    to already keep dt below tau everywhere.
+    """
+    net_dict, models_map, tau1, tau2, length1, length2 = two_delay_lines_netlist
+
+    groups, sys_size, port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    t0, t1 = 0.0, 10e-12
+    ts = jnp.linspace(t0, t1, 400)
+    sol = run_transient(
+        t0=t0, t1=t1, dt0=1e-14, y0=y0, saveat=diffrax.SaveAt(ts=ts),
+        stepsize_controller=diffrax.PIDController(rtol=1e-4, atol=1e-6),
+        max_steps=20000, throw=True,
+    )
+    assert sol.result == diffrax.RESULTS.successful
+    assert sol.stats["num_accepted_steps"] > (t1 - t0) / max(tau1, tau2)
+
+    def complex_at(idx):
+        return sol.ys[:, idx] + 1j * sol.ys[:, idx + sys_size]
+
+    v_out1 = complex_at(port_map["WG1,p2"])
+    v_out2 = complex_at(port_map["WG2,p2"])
+
+    T1 = jnp.exp(-1j * _phase(length1))
+    T2 = jnp.exp(-1j * _phase(length2))
+    expected1 = T1 * _analytic_source(ts - tau1)
+    expected2 = T2 * _analytic_source(ts - tau2)
+
+    assert jnp.max(jnp.abs(v_out1 - expected1)) < 5e-4
+    assert jnp.max(jnp.abs(v_out2 - expected2)) < 5e-4
+    assert jnp.max(jnp.abs(v_out1 - v_out2)) > 0.5
+
+
+def test_delay_line_adaptive_matches_constant_step(two_delay_lines_netlist):
+    """PIDController and ConstantStepSize must agree on the same delay circuit.
+
+    Validates ``jnp.interp``'s accuracy against the irregularly-spaced
+    history buffer produced by adaptive stepping, independent of the
+    analytic model's own discretization noise.
+    """
     net_dict, models_map, *_ = two_delay_lines_netlist
     groups, sys_size, _port_map = compile_netlist(net_dict, models_map)
     linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
     y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
     run_transient = setup_transient(groups, linear_strat)
 
-    with pytest.raises(ValueError, match="ConstantStepSize"):
-        run_transient(
-            t0=0.0, t1=5e-12, dt0=1e-14, y0=y0,
-            saveat=diffrax.SaveAt(ts=jnp.array([4e-12])),
-            stepsize_controller=diffrax.PIDController(rtol=1e-4, atol=1e-6),
-            max_steps=1000, throw=True,
+    t0, t1 = 0.0, 10e-12
+    ts = jnp.linspace(t0, t1, 400)
+
+    sol_adaptive = run_transient(
+        t0=t0, t1=t1, dt0=1e-14, y0=y0, saveat=diffrax.SaveAt(ts=ts),
+        stepsize_controller=diffrax.PIDController(rtol=1e-4, atol=1e-6),
+        max_steps=20000, throw=True,
+    )
+    sol_constant = run_transient(
+        t0=t0, t1=t1, dt0=1e-14, y0=y0, saveat=diffrax.SaveAt(ts=ts),
+        max_steps=2000, throw=True,
+    )
+
+    assert jnp.max(jnp.abs(sol_adaptive.ys - sol_constant.ys)) < 5e-4
+
+
+def test_delay_line_gradient_matches_fd_adaptive():
+    """grad(loss)/d(length_um) under PIDController matches central finite differences.
+
+    Uses the same circuit as ``test_delay_line_gradient_matches_fd`` but
+    evaluates at a point on the pulse's rising edge (``ts=3.05e-12``, not the
+    settled ``4.5e-12`` used by the constant-step version): deep in the
+    settled region the true derivative is tiny (~1e-7) and gets swamped by
+    the adaptive mesh's own discretization noise, which differs slightly
+    between the independently-adapted +h/-h solves -- a false positive for a
+    gradient bug. On the rising edge the signal is large enough that this
+    mesh-selection noise is negligible by comparison.
+    """
+    tau = 1e-12
+    length_um0 = _tau_to_length_um(tau)
+
+    models_map = {
+        "source": OpticalSourcePulse,
+        "delay": OpticalDelayLine,
+        "resistor": Resistor,
+        "ground": lambda: 0,
+    }
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "I1": {
+                "component": "source",
+                "settings": {"power": 1.0, "phase": 0.0, "delay": _PULSE_DELAY, "rise": _PULSE_RISE},
+            },
+            "WG1": {"component": "delay", "settings": {"length_um": length_um0, "n_group": _N_GROUP, "loss_dB_cm": 0.0}},
+            "R1": {"component": "resistor", "settings": {"R": 1.0}},
+        },
+        "connections": {
+            "GND,p1": ("I1,p2", "R1,p2"),
+            "I1,p1": "WG1,p1",
+            "WG1,p2": "R1,p1",
+        },
+    }
+    groups, sys_size, port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    idx_out = port_map["WG1,p2"]
+    t0, t1, dt0 = 0.0, 5e-12, 1e-14
+    ts = jnp.array([3.05e-12])  # on the rising edge (arrival ~= delay + tau = 3e-12)
+    controller = diffrax.PIDController(rtol=1e-4, atol=1e-6)
+
+    def loss_fn(length_um):
+        new_params = eqx.tree_at(lambda p: p.length_um, groups["delay"].params, jnp.array([length_um]))
+        new_group = eqx.tree_at(lambda g: g.params, groups["delay"], new_params)
+        new_groups = dict(groups)
+        new_groups["delay"] = new_group
+
+        sol = run_transient(
+            t0=t0, t1=t1, dt0=dt0, y0=y0, saveat=diffrax.SaveAt(ts=ts), max_steps=5000, throw=True,
+            args=(new_groups, sys_size), stepsize_controller=controller,
         )
+        v_out = sol.ys[0, idx_out] + 1j * sol.ys[0, idx_out + sys_size]
+        return jnp.abs(v_out) ** 2
+
+    grad_val = jax.grad(loss_fn)(length_um0)
+
+    h = 1e-4 * length_um0
+    fd = (loss_fn(length_um0 + h) - loss_fn(length_um0 - h)) / (2 * h)
+
+    assert grad_val == pytest.approx(fd, rel=0.1)
 
 
 def test_undelayed_circuit_unaffected(simple_lrc_netlist):

--- a/tests/test_delay.py
+++ b/tests/test_delay.py
@@ -1,0 +1,246 @@
+"""Tests for fixed time-delay support (see gdsfactory/circulax#2).
+
+Verifies:
+  - A delay-line component's transient output matches an analytically
+    time-shifted, attenuated/phase-shifted copy of its (simulated) input --
+    including two instances of *different* lengths in the same component
+    group, exercising the per-instance-varying-tau vmap path.
+  - Gradients w.r.t. a delay-driving parameter (``length_um``) match finite
+    differences through the checkpointed adjoint.
+  - The ``tau >= dt`` guard rejects delays shorter than the step size.
+  - Adaptive step-size controllers are rejected for delayed circuits (v1
+    requires ConstantStepSize).
+"""
+
+import diffrax
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import pytest
+
+from circulax.compiler import compile_netlist
+from circulax.components.electronic import Resistor
+from circulax.components.photonic import OpticalDelayLine, OpticalSourcePulse
+from circulax.solvers import analyze_circuit, setup_transient
+
+_C_UM_PER_S = 2.99792458e14  # speed of light, um/s
+
+# Pulse delayed well past the sigmoid's floor so the DC operating point (which
+# has no notion of delay history) is ~0 and doesn't leak into the comparison.
+_PULSE_DELAY = 2.0e-12
+_PULSE_RISE = 0.1e-12
+_N_GROUP = 4.0
+
+
+def _tau_to_length_um(tau: float, n_group: float = _N_GROUP) -> float:
+    return tau * _C_UM_PER_S / n_group
+
+
+def _phase(length_um: float, neff: float = 2.4, wavelength_nm: float = 1310.0) -> float:
+    return 2.0 * jnp.pi * neff * (length_um / wavelength_nm) * 1000.0
+
+
+def _analytic_source(t):
+    return jax.nn.sigmoid((t - _PULSE_DELAY) / _PULSE_RISE)
+
+
+@pytest.fixture
+def two_delay_lines_netlist():
+    """Source driving two OpticalDelayLine instances of different lengths, each to its own load."""
+    tau1, tau2 = 1e-12, 2e-12
+    length1, length2 = _tau_to_length_um(tau1), _tau_to_length_um(tau2)
+
+    models_map = {
+        "source": OpticalSourcePulse,
+        "delay": OpticalDelayLine,
+        "resistor": Resistor,
+        "ground": lambda: 0,
+    }
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "I1": {
+                "component": "source",
+                "settings": {"power": 1.0, "phase": 0.0, "delay": _PULSE_DELAY, "rise": _PULSE_RISE},
+            },
+            "WG1": {"component": "delay", "settings": {"length_um": length1, "n_group": _N_GROUP, "loss_dB_cm": 0.0}},
+            "WG2": {"component": "delay", "settings": {"length_um": length2, "n_group": _N_GROUP, "loss_dB_cm": 0.0}},
+            "R1": {"component": "resistor", "settings": {"R": 1.0}},
+            "R2": {"component": "resistor", "settings": {"R": 1.0}},
+        },
+        "connections": {
+            "GND,p1": ("I1,p2", "R1,p2", "R2,p2"),
+            "I1,p1": ("WG1,p1", "WG2,p1"),
+            "WG1,p2": "R1,p1",
+            "WG2,p2": "R2,p1",
+        },
+    }
+    return net_dict, models_map, tau1, tau2, length1, length2
+
+
+def test_delay_line_matches_analytic_shift(two_delay_lines_netlist):
+    """Two delay-line instances of different lengths in one group each match their own tau.
+
+    This exercises the case the design explicitly calls out: because tau
+    varies per instance, the delayed read must vmap the interpolation itself
+    rather than compute one shared delayed vector and slice it.
+    """
+    net_dict, models_map, tau1, tau2, length1, length2 = two_delay_lines_netlist
+
+    groups, sys_size, port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    t0, t1, dt0 = 0.0, 10e-12, 1e-14
+    ts = jnp.linspace(t0, t1, 400)
+    sol = run_transient(
+        t0=t0, t1=t1, dt0=dt0, y0=y0, saveat=diffrax.SaveAt(ts=ts), max_steps=2000, throw=True,
+    )
+
+    def complex_at(idx):
+        return sol.ys[:, idx] + 1j * sol.ys[:, idx + sys_size]
+
+    v_out1 = complex_at(port_map["WG1,p2"])
+    v_out2 = complex_at(port_map["WG2,p2"])
+
+    T1 = jnp.exp(-1j * _phase(length1))
+    T2 = jnp.exp(-1j * _phase(length2))
+    expected1 = T1 * _analytic_source(ts - tau1)
+    expected2 = T2 * _analytic_source(ts - tau2)
+
+    # Loose-ish tolerance: dt0=1e-14 resolves the 0.1ps rise time with ~10
+    # steps, so some linear-interpolation error against the analytic sigmoid
+    # is expected; a broken delay (wrong tau, ignored per-instance variation,
+    # etc.) would miss by order-1, not by this discretization noise.
+    assert jnp.max(jnp.abs(v_out1 - expected1)) < 5e-4
+    assert jnp.max(jnp.abs(v_out2 - expected2)) < 5e-4
+
+    # The two instances must actually differ -- catches a bug where tau is
+    # silently shared across the group instead of read per-instance.
+    assert jnp.max(jnp.abs(v_out1 - v_out2)) > 0.5
+
+
+def test_delay_line_gradient_matches_fd():
+    """grad(loss)/d(length_um) through the delay read matches central finite differences."""
+    tau = 1e-12
+    length_um0 = _tau_to_length_um(tau)
+
+    models_map = {
+        "source": OpticalSourcePulse,
+        "delay": OpticalDelayLine,
+        "resistor": Resistor,
+        "ground": lambda: 0,
+    }
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "I1": {
+                "component": "source",
+                "settings": {"power": 1.0, "phase": 0.0, "delay": _PULSE_DELAY, "rise": _PULSE_RISE},
+            },
+            "WG1": {"component": "delay", "settings": {"length_um": length_um0, "n_group": _N_GROUP, "loss_dB_cm": 0.0}},
+            "R1": {"component": "resistor", "settings": {"R": 1.0}},
+        },
+        "connections": {
+            "GND,p1": ("I1,p2", "R1,p2"),
+            "I1,p1": "WG1,p1",
+            "WG1,p2": "R1,p1",
+        },
+    }
+    groups, sys_size, port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    idx_out = port_map["WG1,p2"]
+    t0, t1, dt0 = 0.0, 5e-12, 1e-14
+    ts = jnp.array([4.5e-12])  # well past tau + rise, in the settled region
+
+    def loss_fn(length_um):
+        new_params = eqx.tree_at(lambda p: p.length_um, groups["delay"].params, jnp.array([length_um]))
+        new_group = eqx.tree_at(lambda g: g.params, groups["delay"], new_params)
+        new_groups = dict(groups)
+        new_groups["delay"] = new_group
+
+        sol = run_transient(
+            t0=t0, t1=t1, dt0=dt0, y0=y0, saveat=diffrax.SaveAt(ts=ts), max_steps=2000, throw=True,
+            args=(new_groups, sys_size),
+        )
+        v_out = sol.ys[0, idx_out] + 1j * sol.ys[0, idx_out + sys_size]
+        return jnp.abs(v_out) ** 2
+
+    grad_val = jax.grad(loss_fn)(length_um0)
+
+    h = 1e-4 * length_um0
+    fd = (loss_fn(length_um0 + h) - loss_fn(length_um0 - h)) / (2 * h)
+
+    assert grad_val == pytest.approx(fd, rel=0.1)
+
+
+def test_delay_shorter_than_dt_raises():
+    """tau < dt must be rejected -- the history buffer can't resolve it."""
+    models_map = {
+        "source": OpticalSourcePulse,
+        "delay": OpticalDelayLine,
+        "resistor": Resistor,
+        "ground": lambda: 0,
+    }
+    net_dict = {
+        "instances": {
+            "GND": {"component": "ground"},
+            "I1": {"component": "source", "settings": {"power": 1.0, "delay": _PULSE_DELAY, "rise": _PULSE_RISE}},
+            # length chosen so tau (~1e-16 s) << dt0 (1e-14 s) below.
+            "WG1": {"component": "delay", "settings": {"length_um": 0.001, "n_group": _N_GROUP}},
+            "R1": {"component": "resistor", "settings": {"R": 1.0}},
+        },
+        "connections": {
+            "GND,p1": ("I1,p2", "R1,p2"),
+            "I1,p1": "WG1,p1",
+            "WG1,p2": "R1,p1",
+        },
+    }
+    groups, sys_size, _port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    with pytest.raises(Exception, match="tau < dt"):
+        run_transient(
+            t0=0.0, t1=5e-12, dt0=1e-14, y0=y0,
+            saveat=diffrax.SaveAt(ts=jnp.array([4e-12])), max_steps=1000, throw=True,
+        )
+
+
+def test_delay_requires_constant_step_size(two_delay_lines_netlist):
+    """Adaptive step-size controllers are rejected for delayed circuits (v1 limitation)."""
+    net_dict, models_map, *_ = two_delay_lines_netlist
+    groups, sys_size, _port_map = compile_netlist(net_dict, models_map)
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense", is_complex=True)
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size * 2, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    with pytest.raises(ValueError, match="ConstantStepSize"):
+        run_transient(
+            t0=0.0, t1=5e-12, dt0=1e-14, y0=y0,
+            saveat=diffrax.SaveAt(ts=jnp.array([4e-12])),
+            stepsize_controller=diffrax.PIDController(rtol=1e-4, atol=1e-6),
+            max_steps=1000, throw=True,
+        )
+
+
+def test_undelayed_circuit_unaffected(simple_lrc_netlist):
+    """A circuit with no delayed components must not allocate/thread a history buffer."""
+    net_dict, models_map = simple_lrc_netlist
+    groups, sys_size, _port_map = compile_netlist(net_dict, models_map)
+    assert all(not getattr(g, "has_delay", False) for g in groups.values())
+
+    linear_strat = analyze_circuit(groups, sys_size, backend="dense")
+    y0 = linear_strat.solve_dc(groups, jnp.zeros(sys_size, dtype=jnp.float64))
+    run_transient = setup_transient(groups, linear_strat)
+
+    sol = run_transient(
+        t0=0.0, t1=1e-8, dt0=1e-10, y0=y0, saveat=diffrax.SaveAt(ts=jnp.linspace(0, 1e-8, 20)),
+        max_steps=5000, throw=True,
+    )
+    assert jnp.all(jnp.isfinite(sol.ys))

--- a/tests/test_rational.py
+++ b/tests/test_rational.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from circulax.compiler import compile_netlist
-from circulax.components.rational import rational_component, rational_fdomain_component
+from circulax.components.rational import rational_component, rational_delay_component, rational_fdomain_component
 from circulax.solvers import analyze_circuit, setup_ac_sweep, setup_transient
 
 jax.config.update("jax_enable_x64", True)
@@ -296,3 +296,101 @@ class TestTransientStability:
         v1_sim = float(sol.ys[0, dut_p1_node])
         np.testing.assert_allclose(v1_sim, v1_expected, rtol=0.01,
                                    err_msg="Transient did not hold at DC divider value")
+
+
+def _measure_s_matrix(Comp, freqs, z0=50.0):
+    """Evaluate S(f) from a component's solver_call Y(f) output."""
+    inst = Comp()
+    Nc = len(Comp.ports)
+    eye = np.eye(Nc, dtype=np.complex128)
+    S = np.zeros((len(freqs), Nc, Nc), dtype=np.complex128)
+    for i, f in enumerate(freqs):
+        Y = np.asarray(Comp.solver_call(float(f), inst))
+        S[i] = (eye - z0 * Y) @ np.linalg.inv(eye + z0 * Y)
+    return S
+
+
+def _group_delay_from_s(S_element, freqs):
+    """Compute group delay from a 1-D array of S-parameter values vs frequency."""
+    phase = np.unwrap(np.angle(S_element))
+    omega = 2.0 * np.pi * freqs
+    return -np.gradient(phase, omega)
+
+
+class TestRationalDelayComponent:
+    """Test the delay+rational composite fdomain component."""
+
+    def test_creates_fdomain_class(self):
+        ss = _make_test_ss()
+        tau = np.array([1e-9, 1e-9])
+        Comp = rational_delay_component(ss, tau)
+        assert Comp._is_fdomain
+        assert Comp.ports == ("p1", "p2")
+
+    def test_s21_group_delay_matches_tau(self):
+        """S21 group delay of composite exceeds rational-only by exactly tau."""
+        ss = _make_test_ss()
+        z0 = 50.0
+        tau_val = 1e-9
+        tau = np.array([tau_val, tau_val])
+
+        Comp_delay = rational_delay_component(ss, tau, name="RatDelay", z0=z0)
+        Comp_nodelay = rational_delay_component(ss, np.array([0.0, 0.0]), name="RatNoDelay", z0=z0)
+
+        freqs = np.linspace(1e9, 15e9, 300)
+
+        S_delay = _measure_s_matrix(Comp_delay, freqs, z0)
+        S_nodelay = _measure_s_matrix(Comp_nodelay, freqs, z0)
+
+        gd_delay = _group_delay_from_s(S_delay[:, 0, 1], freqs)
+        gd_nodelay = _group_delay_from_s(S_nodelay[:, 0, 1], freqs)
+        excess = np.median(gd_delay - gd_nodelay)
+
+        np.testing.assert_allclose(excess, tau_val, rtol=0.03,
+                                   err_msg=f"S21 excess group delay {excess:.3e} != tau {tau_val:.3e}")
+
+    def test_zero_delay_matches_rational_only(self):
+        """With tau=0, the composite should match rational_fdomain_component."""
+        ss = _make_test_ss()
+        tau = np.array([0.0, 0.0])
+
+        Comp_delay = rational_delay_component(ss, tau, name="RatDelayZero")
+        Comp_fd = rational_fdomain_component(ss, name="RatFD0")
+
+        freqs = [1e9, 5e9, 20e9]
+        for f in freqs:
+            Y_delay = Comp_delay.solver_call(f, Comp_delay())
+            Y_fd = Comp_fd.solver_call(f, Comp_fd())
+            np.testing.assert_allclose(np.asarray(Y_delay), np.asarray(Y_fd), atol=1e-10)
+
+    def test_asymmetric_delay(self):
+        """Asymmetric delays: S11 excess GD = tau1, S22 excess GD = tau2."""
+        ss = _make_test_ss()
+        z0 = 50.0
+        tau1, tau2 = 1e-9, 2e-9
+        tau = np.array([tau1, tau2])
+
+        Comp_delay = rational_delay_component(ss, tau, name="AsymDelay", z0=z0)
+        Comp_nodelay = rational_delay_component(ss, np.array([0.0, 0.0]), name="AsymNoDelay", z0=z0)
+
+        freqs = np.linspace(1e9, 15e9, 300)
+        S_delay = _measure_s_matrix(Comp_delay, freqs, z0)
+        S_nodelay = _measure_s_matrix(Comp_nodelay, freqs, z0)
+
+        gd_s11 = _group_delay_from_s(S_delay[:, 0, 0], freqs)
+        gd_s11_ref = _group_delay_from_s(S_nodelay[:, 0, 0], freqs)
+        excess_s11 = np.median(gd_s11 - gd_s11_ref)
+        np.testing.assert_allclose(excess_s11, tau1, rtol=0.05,
+                                   err_msg=f"S11 excess GD {excess_s11:.3e} != tau1 {tau1:.3e}")
+
+        gd_s22 = _group_delay_from_s(S_delay[:, 1, 1], freqs)
+        gd_s22_ref = _group_delay_from_s(S_nodelay[:, 1, 1], freqs)
+        excess_s22 = np.median(gd_s22 - gd_s22_ref)
+        np.testing.assert_allclose(excess_s22, tau2, rtol=0.05,
+                                   err_msg=f"S22 excess GD {excess_s22:.3e} != tau2 {tau2:.3e}")
+
+        gd_s21 = _group_delay_from_s(S_delay[:, 0, 1], freqs)
+        gd_s21_ref = _group_delay_from_s(S_nodelay[:, 0, 1], freqs)
+        excess_s21 = np.median(gd_s21 - gd_s21_ref)
+        np.testing.assert_allclose(excess_s21, (tau1 + tau2) / 2, rtol=0.05,
+                                   err_msg=f"S21 excess GD {excess_s21:.3e} != (tau1+tau2)/2")

--- a/tests/test_rational.py
+++ b/tests/test_rational.py
@@ -1,0 +1,298 @@
+"""Tests for rational component factory: SSModel → circulax @component."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from circulax.compiler import compile_netlist
+from circulax.components.rational import rational_component, rational_fdomain_component
+from circulax.solvers import analyze_circuit, setup_ac_sweep, setup_transient
+
+jax.config.update("jax_enable_x64", True)
+
+
+_TEST_POLES = np.array([-1e9 + 1j * 6e10, -1e9 - 1j * 6e10, -5e9], dtype=np.complex128)
+_TEST_R1 = np.array([[5e7 + 2e7j, -4e7 - 1e7j], [-4e7 - 1e7j, 5e7 + 2e7j]], dtype=np.complex128)
+_TEST_R2 = _TEST_R1.conj()
+_TEST_R3 = np.array([[1e8, -8e7], [-8e7, 1e8]], dtype=np.complex128)
+_TEST_RESIDUES = [_TEST_R1, _TEST_R2, _TEST_R3]
+_TEST_D = np.array([[0.02, -0.019], [-0.019, 0.02]], dtype=np.float64)
+
+
+def _eval_pole_residue(s_pts, poles=_TEST_POLES, residues=_TEST_RESIDUES, D=_TEST_D):
+    """Evaluate Y(s) = D + sum_k R_k/(s - p_k) from raw pole-residue data.
+
+    Independent of the tile/kron/reshape SS packing — serves as the ground-truth
+    oracle that catches packing bugs invisible to _eval_ss.
+    """
+    result = np.zeros((len(s_pts), D.shape[0], D.shape[1]), dtype=np.complex128)
+    for i, s in enumerate(np.asarray(s_pts)):
+        Y = D.astype(np.complex128).copy()
+        for p, R in zip(poles, residues):
+            Y = Y + R / (s - p)
+        result[i] = Y
+    return result
+
+
+def _make_test_ss():
+    """Build a simple 2-port SSModel-like object with known poles."""
+    poles = np.array([-1e9 + 1j * 6e10, -1e9 - 1j * 6e10, -5e9], dtype=np.complex128)
+    Nc = 2
+    N = len(poles)
+
+    R1 = np.array([[5e7 + 2e7j, -4e7 - 1e7j], [-4e7 - 1e7j, 5e7 + 2e7j]], dtype=np.complex128)
+    R2 = R1.conj()
+    R3 = np.array([[1e8, -8e7], [-8e7, 1e8]], dtype=np.complex128)
+    residues = np.stack([R1, R2, R3], axis=-1)
+
+    D = np.array([[0.02, -0.019], [-0.019, 0.02]], dtype=np.float64)
+    E = np.zeros((Nc, Nc), dtype=np.float64)
+
+    A_diag = np.tile(poles, Nc)
+    B = np.kron(np.eye(Nc, dtype=np.complex128), np.ones((N, 1), dtype=np.complex128))
+    C = residues.reshape(Nc, Nc * N)
+
+    return SimpleNamespace(
+        A=jnp.array(A_diag),
+        B=jnp.array(B),
+        C=jnp.array(C),
+        D=jnp.array(D, dtype=jnp.complex128),
+        E=jnp.array(E, dtype=jnp.complex128),
+    )
+
+
+class TestRationalComponent:
+    """Test the rational_component factory."""
+
+    @pytest.fixture
+    def ss(self):
+        return _make_test_ss()
+
+    def test_creates_component_class(self, ss):
+        Comp = rational_component(ss, name="TestComp")
+        assert Comp.ports == ("p1", "p2")
+        assert len(Comp.states) == 6
+
+    def test_instantiate_and_call(self, ss):
+        Comp = rational_component(ss)
+        inst = Comp()
+        n_vars = len(Comp.ports) + len(Comp.states)
+        y = jnp.zeros(n_vars, dtype=jnp.complex128)
+        f, q = inst(y)
+        assert set(f.keys()) == set(Comp.ports + Comp.states)
+        assert set(q.keys()) == set(Comp.ports + Comp.states)
+
+    def test_solver_call(self, ss):
+        Comp = rational_component(ss)
+        n_vars = len(Comp.ports) + len(Comp.states)
+        y = jnp.zeros(n_vars, dtype=jnp.complex128)
+        f_vec, q_vec = Comp.solver_call(0.0, y, Comp())
+        assert f_vec.shape == (n_vars,)
+        assert q_vec.shape == (n_vars,)
+        assert jnp.all(jnp.isfinite(f_vec))
+        assert jnp.all(jnp.isfinite(q_vec))
+
+    def test_dc_response(self, ss):
+        """At DC-consistent (v, x) state, i_port = H(0) @ v from pole-residue sum."""
+        Comp = rational_component(ss)
+        n_p = len(Comp.ports)
+
+        H0 = _eval_pole_residue(np.array([0.0]), _TEST_POLES, _TEST_RESIDUES, _TEST_D)[0]
+        v = jnp.array([1.0 + 0j, 0.5 + 0j])
+        A = np.asarray(ss.A)
+        B = np.asarray(ss.B)
+        x = jnp.array(-(B @ np.asarray(v)) / A)
+        y = jnp.concatenate([v, x])
+
+        f_vec, _ = Comp.solver_call(0.0, y, Comp())
+        np.testing.assert_allclose(np.asarray(f_vec[n_p:]), 0.0, atol=1e-6,
+                                   err_msg="State equations not zero at consistent point")
+        i_expected = H0 @ np.asarray(v)
+        np.testing.assert_allclose(np.asarray(f_vec[:n_p]), i_expected, rtol=1e-8,
+                                   err_msg="Port current != H(0) @ v")
+
+    def test_origin_pole_raises(self):
+        bad_ss = SimpleNamespace(
+            A=jnp.array([0.0 + 0j, -1e9 + 0j]),
+            B=jnp.ones((2, 1), dtype=jnp.complex128),
+            C=jnp.ones((1, 2), dtype=jnp.complex128),
+            D=jnp.zeros((1, 1), dtype=jnp.complex128),
+            E=jnp.zeros((1, 1), dtype=jnp.complex128),
+        )
+        with pytest.raises(ValueError, match="pole at or near the origin"):
+            rational_component(bad_ss)
+
+
+class TestRationalFdomainComponent:
+    """Test the frequency-domain oracle."""
+
+    @pytest.fixture
+    def ss(self):
+        return _make_test_ss()
+
+    def test_creates_fdomain_class(self, ss):
+        Comp = rational_fdomain_component(ss)
+        assert Comp._is_fdomain
+        assert Comp.ports == ("p1", "p2")
+
+    def test_solver_call_matches_pole_residue(self, ss):
+        """Fdomain component matches the independent pole-residue oracle."""
+        Comp = rational_fdomain_component(ss)
+        freqs = np.array([1e9, 5e9, 10e9, 20e9])
+        s_pts = 1j * 2 * np.pi * freqs
+        H_ref = _eval_pole_residue(s_pts)
+
+        for i, f in enumerate(freqs):
+            Y = Comp.solver_call(float(f), Comp())
+            np.testing.assert_allclose(np.asarray(Y), H_ref[i], atol=1e-10)
+
+
+class TestFourWayAgreement:
+    """Verify rational_component, rational_fdomain_component, eval_ss, and
+    the original Y data all agree in AC sweep."""
+
+    @pytest.fixture
+    def setup(self):
+        from circulax.components.electronic import Resistor
+        ss = _make_test_ss()
+        z0 = 50.0
+
+        Comp_td = rational_component(ss, name="RatTD", z0=z0)
+        Comp_fd = rational_fdomain_component(ss, name="RatFD")
+
+        net = {
+            "instances": {
+                "GND": {"component": "ground"},
+                "DUT": {"component": "dut", "settings": {}},
+                "R1": {"component": "resistor", "settings": {"R": z0}},
+                "R2": {"component": "resistor", "settings": {"R": z0}},
+            },
+            "connections": {
+                "R1,p2": "DUT,p1",
+                "R2,p2": "DUT,p2",
+                "R1,p1": "GND,p1",
+                "R2,p1": "GND,p1",
+            },
+            "ports": {"port1": "DUT,p1", "port2": "DUT,p2"},
+        }
+
+        models_td = {"dut": Comp_td, "resistor": Resistor, "ground": lambda: 0}
+        groups_td, num_vars_td, pmap_td = compile_netlist(net, models_td)
+        solver_td = analyze_circuit(groups_td, num_vars_td, backend="dense", is_complex=True)
+        y_dc_td = solver_td.solve_dc(groups_td, jnp.zeros(num_vars_td * 2, dtype=jnp.float64))
+        port_nodes_td = [pmap_td["DUT,p1"], pmap_td["DUT,p2"]]
+        run_ac_td = setup_ac_sweep(groups_td, num_vars_td, port_nodes_td, z0=z0, is_complex=True)
+
+        models_fd = {"dut": Comp_fd, "resistor": Resistor, "ground": lambda: 0}
+        groups_fd, num_vars_fd, pmap_fd = compile_netlist(net, models_fd)
+        solver_fd = analyze_circuit(groups_fd, num_vars_fd, backend="dense", is_complex=True)
+        y_dc_fd = solver_fd.solve_dc(groups_fd, jnp.zeros(num_vars_fd * 2, dtype=jnp.float64))
+        port_nodes_fd = [pmap_fd["DUT,p1"], pmap_fd["DUT,p2"]]
+        run_ac_fd = setup_ac_sweep(groups_fd, num_vars_fd, port_nodes_fd, z0=z0, is_complex=True)
+
+        return ss, run_ac_td, y_dc_td, run_ac_fd, y_dc_fd
+
+    def test_ac_sweep_agreement(self, setup):
+        """Time-domain and fdomain components produce identical S-parameters.
+
+        Both are embedded in the same 2-port testbench (R1=R2=z0 shunt to GND),
+        so the S-params include the port termination. The key check is that
+        rational_component (DAE stamp) agrees with rational_fdomain_component
+        (direct H(j2*pi*f) evaluation) — any difference means the DAE mapping
+        is wrong.
+        """
+        ss, run_ac_td, y_dc_td, run_ac_fd, y_dc_fd = setup
+        freqs = jnp.logspace(7, 10.3, 30)
+
+        S_td = run_ac_td(y_dc_td, freqs)
+        S_fd = run_ac_fd(y_dc_fd, freqs)
+
+        np.testing.assert_allclose(np.asarray(S_td), np.asarray(S_fd), atol=1e-8,
+                                   err_msg="Time-domain vs fdomain component disagree")
+
+    def test_ac_sweep_matches_pole_residue_oracle(self, setup):
+        """S-params from AC sweep recover the original Y data after de-embedding port termination."""
+        from circulax.s_transforms import s_to_y
+
+        ss, run_ac_td, y_dc_td, _, _ = setup
+        z0 = 50.0
+        freqs = jnp.logspace(8, 10.3, 20)
+        s_pts = 1j * 2 * np.pi * np.asarray(freqs)
+
+        S_td = np.asarray(run_ac_td(y_dc_td, freqs))
+        Y_ref = _eval_pole_residue(s_pts)
+
+        for k in range(len(freqs)):
+            Y_circuit = np.asarray(s_to_y(jnp.array(S_td[k]), z0=z0))
+            Y_dut = Y_circuit - np.eye(2) / z0
+            np.testing.assert_allclose(Y_dut, Y_ref[k], rtol=1e-6,
+                                       err_msg=f"Y mismatch at f={float(freqs[k]):.2e}")
+
+    def test_ac_sweep_finite(self, setup):
+        ss, run_ac_td, y_dc_td, run_ac_fd, y_dc_fd = setup
+        freqs = jnp.logspace(7, 10.3, 20)
+        S = run_ac_td(y_dc_td, freqs)
+        assert jnp.all(jnp.isfinite(S))
+        assert S.shape == (len(freqs), 2, 2)
+
+
+class TestTransientStability:
+    """Verify the rational component settles to correct DC steady state."""
+
+    def test_step_response_settles(self):
+        import diffrax
+
+        from circulax.components.electronic import Resistor, VoltageSource
+
+        ss = _make_test_ss()
+        z0 = 50.0
+        Comp = rational_component(ss, name="RatTransient", z0=z0)
+
+        net = {
+            "instances": {
+                "GND": {"component": "ground"},
+                "V1": {"component": "vsrc", "settings": {"V": 1.0}},
+                "R1": {"component": "resistor", "settings": {"R": z0}},
+                "DUT": {"component": "dut", "settings": {}},
+            },
+            "connections": {
+                "V1,p1": "R1,p1",
+                "R1,p2": "DUT,p1",
+                "V1,p2": "GND,p1",
+                "DUT,p2": "GND,p1",
+            },
+        }
+        models = {
+            "ground": lambda: 0,
+            "vsrc": VoltageSource,
+            "resistor": Resistor,
+            "dut": Comp,
+        }
+        groups, num_vars, pmap = compile_netlist(net, models)
+        solver = analyze_circuit(groups, num_vars, backend="dense", is_complex=True)
+        y_dc = solver.solve_dc(groups, jnp.zeros(num_vars * 2, dtype=jnp.float64))
+
+        run_transient = setup_transient(groups, solver)
+        sol = run_transient(
+            t0=0.0,
+            t1=10e-9,
+            dt0=1e-12,
+            y0=y_dc,
+            saveat=diffrax.SaveAt(ts=jnp.array([9e-9])),
+            max_steps=50000,
+        )
+
+        assert jnp.all(jnp.isfinite(sol.ys)), "Transient solution diverged"
+
+        H0 = _eval_pole_residue(np.array([0.0]))[0]
+        Y11_dc = H0[0, 0].real
+        v1_expected = 1.0 / (1.0 + z0 * Y11_dc)
+
+        dut_p1_node = pmap["DUT,p1"]
+        v1_sim = float(sol.ys[0, dut_p1_node])
+        np.testing.assert_allclose(v1_sim, v1_expected, rtol=0.01,
+                                   err_msg="Transient did not hold at DC divider value")


### PR DESCRIPTION
## Summary

- **Transient delay infrastructure**: DDE history buffer, OpticalDelayLine component, adaptive step-size support (8 tests)
- **Rational component factories**: `rational_component` (time-domain DAE), `rational_fdomain_component` (AC/HB oracle), `rational_delay_component` (delay+rational cascade) from vfitax SSModel data (15 tests)
- **AC sweep fix**: correct complex-voltage extraction from 2N real-block form
- **Specs**: time-delay spec (updated for transient+fdomain coexistence), vector-fitting spec

## Details

- feat(solvers): add fixed time-delay support for circuit components
- feat(solvers): add adaptive step-size support for time-delayed circuits
- feat(components): add rational factory functions for vector fitting
- feat(components): add rational_delay_component for vector fitting with delay
- docs(specs): add vector-fitting spec, update time-delay for Phase 4

15 files changed, 2143 insertions, 130 deletions.
All 291 tests pass with no regressions.